### PR TITLE
Add ALT support

### DIFF
--- a/v2v/convert_linux.mli
+++ b/v2v/convert_linux.mli
@@ -19,7 +19,7 @@
 (** Convert a Linux guest to run on KVM.
 
     This module converts certain Enterprise Linux guests to run on
-    KVM.  RHEL, SuSE, Fedora, CentOS, OracleLinux, Debian, Ubuntu,
+    KVM.  RHEL, SuSE, Fedora, CentOS, OracleLinux, ALT, Debian, Ubuntu,
     Mint and Kali are supported by this module.
 
     No functions are exported.  When the module is linked to virt-v2v


### PR DESCRIPTION
Add support of ALT linux (https://en.altlinux.org/) guests to virt-v2v.