### PR TITLE
fix rhv-upload function to work with keycloak instead of basic auth only

### DIFF
--- a/output/rhv-upload-cancel.py
+++ b/output/rhv-upload-cancel.py
@@ -20,7 +20,7 @@ import json
 import logging
 import sys
 from contextlib import closing
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
@@ -52,10 +52,11 @@ output_password = output_password.rstrip()
 # Parse out the username from the output_conn URL.
 parsed = urlparse(params['output_conn'])
 username = parsed.username or "admin@internal"
+netloc = f"{parsed.hostname:parsed.port}" if parsed.port else parsed.hostname
 
 # Connect to the server.
 connection = sdk.Connection(
-    url=params['output_conn'],
+    url=urlunparse(parsed._replace(netloc=netloc)),
     username=username,
     password=output_password,
     ca_file=params['rhv_cafile'],

--- a/output/rhv-upload-createvm.py
+++ b/output/rhv-upload-createvm.py
@@ -22,7 +22,7 @@ import sys
 import time
 import uuid
 
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
@@ -92,10 +92,11 @@ with open(sys.argv[2], 'r') as fp:
 # Parse out the username from the output_conn URL.
 parsed = urlparse(params['output_conn'])
 username = parsed.username or "admin@internal"
+netloc = f"{parsed.hostname:parsed.port}" if parsed.port else parsed.hostname
 
 # Connect to the server.
 connection = sdk.Connection(
-    url=params['output_conn'],
+    url=urlunparse(parsed._replace(netloc=netloc)),
     username=username,
     password=output_password,
     ca_file=params['rhv_cafile'],

--- a/output/rhv-upload-finalize.py
+++ b/output/rhv-upload-finalize.py
@@ -20,7 +20,7 @@ import json
 import logging
 import sys
 import time
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
@@ -155,10 +155,11 @@ output_password = output_password.rstrip()
 # Parse out the username from the output_conn URL.
 parsed = urlparse(params['output_conn'])
 username = parsed.username or "admin@internal"
+netloc = f"{parsed.hostname:parsed.port}" if parsed.port else parsed.hostname
 
 # Connect to the server.
 connection = sdk.Connection(
-    url=params['output_conn'],
+    url=urlunparse(parsed._replace(netloc=netloc)),
     username=username,
     password=output_password,
     ca_file=params['rhv_cafile'],

--- a/output/rhv-upload-plugin.py
+++ b/output/rhv-upload-plugin.py
@@ -25,7 +25,7 @@ import time
 
 from contextlib import contextmanager
 from http.client import HTTPSConnection, HTTPConnection
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import nbdkit
 

--- a/output/rhv-upload-plugin.py
+++ b/output/rhv-upload-plugin.py
@@ -25,7 +25,7 @@ import time
 
 from contextlib import contextmanager
 from http.client import HTTPSConnection, HTTPConnection
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse
 
 import nbdkit
 

--- a/output/rhv-upload-precheck.py
+++ b/output/rhv-upload-precheck.py
@@ -59,7 +59,7 @@ if not re.match('^[-a-zA-Z0-9_]+$', output_storage):
 
 # Connect to the server.
 connection = sdk.Connection(
-    url=urlunparse(parsed._replace(netloc=netloc)),        
+    url=urlunparse(parsed._replace(netloc=netloc)),
     username=username,
     password=output_password,
     ca_file=params['rhv_cafile'],

--- a/output/rhv-upload-precheck.py
+++ b/output/rhv-upload-precheck.py
@@ -21,7 +21,7 @@ import logging
 import re
 import sys
 
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
@@ -46,6 +46,7 @@ output_password = output_password.rstrip()
 # Parse out the username from the output_conn URL.
 parsed = urlparse(params['output_conn'])
 username = parsed.username or "admin@internal"
+netloc = f"{parsed.hostname:parsed.port}" if parsed.port else parsed.hostname
 
 # Check the storage domain name is valid
 # (https://bugzilla.redhat.com/show_bug.cgi?id=1986386#c1)
@@ -58,7 +59,7 @@ if not re.match('^[-a-zA-Z0-9_]+$', output_storage):
 
 # Connect to the server.
 connection = sdk.Connection(
-    url=params['output_conn'],
+    url=urlunparse(parsed._replace(netloc=netloc)),        
     username=username,
     password=output_password,
     ca_file=params['rhv_cafile'],

--- a/output/rhv-upload-transfer.py
+++ b/output/rhv-upload-transfer.py
@@ -22,7 +22,7 @@ import logging
 import sys
 import time
 from contextlib import closing
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
@@ -259,9 +259,10 @@ output_password = output_password.rstrip()
 # Parse out the username from the output_conn URL.
 parsed = urlparse(params['output_conn'])
 username = parsed.username or "admin@internal"
+netloc = f"{parsed.hostname:parsed.port}" if parsed.port else parsed.hostname
 
 connection = sdk.Connection(
-    url=params['output_conn'],
+    url=urlunparse(parsed._replace(netloc=netloc)),
     username=username,
     password=output_password,
     ca_file=params['rhv_cafile'],

--- a/output/rhv-upload-vmcheck.py
+++ b/output/rhv-upload-vmcheck.py
@@ -20,7 +20,7 @@ import json
 import logging
 import sys
 
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
@@ -45,10 +45,11 @@ output_password = output_password.rstrip()
 # Parse out the username from the output_conn URL.
 parsed = urlparse(params['output_conn'])
 username = parsed.username or "admin@internal"
+netloc = f"{parsed.hostname:parsed.port}" if parsed.port else parsed.hostname
 
 # Connect to the server.
 connection = sdk.Connection(
-    url=params['output_conn'],
+    url=urlunparse(parsed._replace(netloc=netloc)),
     username=username,
     password=output_password,
     ca_file=params['rhv_cafile'],


### PR DESCRIPTION
As discusses here are a working change to be able  to use keycloak URL's like this.

https://admin@ovirt@internalsso@hostname/ovirt-engine/api

Thx again for the help and the quick fix