### PR TITLE
-o rhv-upload: Add context if parsing params fails

### DIFF
--- a/output/rhv-upload-transfer.py
+++ b/output/rhv-upload-transfer.py
@@ -249,7 +249,14 @@ if len(sys.argv) != 2:
 
 # Parameters are passed in via a JSON document.
 with open(sys.argv[1], 'r') as fp:
-    params = json.load(fp)
+    data = fp.read()
+
+try:
+    params = json.loads(data)
+except ValueError as e:
+    raise RuntimeError(f"Cannot parse params {data!r}: {e}").with_traceback(
+        e.__traceback__
+    ) from None
 
 # What is passed in is a password file, read the actual password.
 with open(params['output_password'], 'r') as fp:


### PR DESCRIPTION
If parsing params fail we get unhelpful error:

    virt-v2v: error: internal error: invalid argument:
    /tmp/v2v.CtVpBL/v2vtransfer.json: JSON parse error: end of file expected
    near 'e'

Change the parsing code to read the entire json text and include it in the error message. This will make it clear why the json could not be parsed, and help to find the root cause for having invalid json.

Example error:

    $ cat out.params0.json
    This is not a json document

    $ python output/rhv-upload-transfer.py out.params0.json
    Traceback (most recent call last):
      File "/home/nsoffer/src/virt-v2v/output/rhv-upload-transfer.py", line 261, in <module>
        raise RuntimeError(f"Cannot parse params {data!r}: {e}").with_traceback(
      File "/home/nsoffer/src/virt-v2v/output/rhv-upload-transfer.py", line 259, in <module>
        params = json.loads(data)
                 ^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.12/json/__init__.py", line 346, in loads
        return _default_decoder.decode(s)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.12/json/decoder.py", line 337, in decode
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.12/json/decoder.py", line 355, in raw_decode
        raise JSONDecodeError("Expecting value", s, err.value) from None
    RuntimeError: Cannot parse params 'This is not a json document\n': Expecting value: line 1 column 1 (char 0)

Related to #46