### PR TITLE
Improve rhv-upload output and logging

### DIFF
--- a/output/rhv-upload-transfer.py
+++ b/output/rhv-upload-transfer.py
@@ -285,10 +285,10 @@ with closing(connection):
     transfer = create_transfer(connection, disk, host)
     destination_url = get_transfer_url(transfer)
 
-    # Send the destination URL, transfer ID, and host flag back to OCaml code.
-    results = {
-        "transfer_id": transfer.id,
-        "destination_url": destination_url,
-        "is_ovirt_host": host is not None,
-    }
-    json.dump(results, sys.stdout)
+# Send the destination URL, transfer ID, and host flag back to OCaml code.
+results = {
+    "transfer_id": transfer.id,
+    "destination_url": destination_url,
+    "is_ovirt_host": host is not None,
+}
+json.dump(results, sys.stdout)

--- a/output/rhv-upload-transfer.py
+++ b/output/rhv-upload-transfer.py
@@ -43,9 +43,13 @@ def find_host(connection):
     try:
         with open("/etc/vdsm/vdsm.id") as f:
             vdsm_id = f.readline().strip()
+    except FileNotFoundError:
+        # Expected condition when running on non-oVirt host.
+        debug("not an oVirt host, using any host")
+        return None
     except Exception as e:
-        # This is most likely not an oVirt host.
-        debug("cannot read /etc/vdsm/vdsm.id, not running on an ovirt host [this is not an error]: original exception: %s" % e)
+        # Unexpected but we can degrade to remote transfer.
+        debug(f"warning: cannot read host id, using any host: {e}")
         return None
 
     debug("hw_id = %r" % vdsm_id)


### PR DESCRIPTION
- Move output outside of the with block to avoid unwanted output after the end of the json.
- Improve logging when reading vdsm id file fails