### PR TITLE
convert: Reload augeas after package remove

### DIFF
--- a/convert/convert_linux.ml
+++ b/convert/convert_linux.ml
@@ -144,7 +144,9 @@ let convert (g : G.guestfs) source inspect i_firmware _ keep_serial_console _ =
        with G.Error msg ->
          warning (f_"could not uninstall packages ‘%s’: %s (ignored)")
            (String.concat " " pkgs) msg
-      )
+      );
+      (* Reload Augeas in case anything changed. *)
+      Linux.augeas_reload g
     )
   in
 


### PR DESCRIPTION
This was previously done by Linux.remove. Do the same for uninstall_packages