### PR TITLE
Remove some RHEL3 adjacent bits

### DIFF
--- a/convert/convert_linux.ml
+++ b/convert/convert_linux.ml
@@ -825,27 +825,6 @@ let convert (g : G.guestfs) source inspect i_firmware _ keep_serial_console _ =
          *)
         (try g#modprobe "loop" with G.Error _ -> ());
 
-        (* On RHEL 3 we have to take extra gritty to get a working
-         * loopdev.  mkinitrd runs the nash command `findlodev'
-         * which does this:
-         *
-         * for (devNum = 0; devNum < 256; devNum++) {
-         *   sprintf(devName, "/dev/loop%s%d", separator, devNum);
-         *   if ((fd = open(devName, O_RDONLY)) < 0) return 0;
-         *   if (ioctl(fd, LOOP_GET_STATUS, &loopInfo)) {
-         *     close(fd);
-         *     printf("%s\n", devName);
-         *     return 0;
-         * // etc
-         *
-         * In a modern kernel, /dev/loop<N> isn't created until it is
-         * used.  But we can create /dev/loop0 manually.  Note we have
-         * to do this in the appliance /dev.  (RHBZ#1171130)
-         *)
-        if family = `RHEL_family && inspect.i_major_version = 3 then
-          ignore (g#debug "sh" [| "mknod"; "-m"; "0666";
-                                  "/dev/loop0"; "b"; "7"; "0" |]);
-
         (* RHEL 4 mkinitrd determines if the root filesystem is on LVM
          * by checking if the device name (after following symlinks)
          * starts with /dev/mapper. However, on recent kernels/udevs,

--- a/docs/virt-v2v.pod
+++ b/docs/virt-v2v.pod
@@ -900,8 +900,6 @@ Therefore before conversion you should check that a regular kernel is
 installed.  For some older Linux distributions, this means installing
 a kernel from the table below:
 
- RHEL 3         (Does not apply, as there was no Xen PV kernel)
- 
  RHEL 4         i686 with > 10GB of RAM: install 'kernel-hugemem'
                 i686 SMP: install 'kernel-smp'
                 other i686: install 'kernel'
@@ -938,8 +936,6 @@ after conversion, you should ensure that the B<minimum> versions of
 packages are installed I<before> conversion, by consulting the table
 below.
 
- RHEL 3         No virtio drivers are available
- 
  RHEL 4         kernel >= 2.5.9-89.EL
                 lvm2 >= 2.02.42-5.el4
                 device-mapper >= 1.02.28-2.el4

--- a/lib/create_ovf.ml
+++ b/lib/create_ovf.ml
@@ -56,18 +56,18 @@ let iso_time =
 
 (* Guess vmtype based on the guest inspection data. *)
 let get_vmtype = function
-  (* Special cases for RHEL 3 & RHEL 4. *)
-  | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = (3|4);
+  (* Special cases for RHEL 4. *)
+  | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = 4;
       i_product_name = product }
        when String.find product "ES" >= 0 ->
      `Server
 
-  | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = (3|4);
+  | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = 4;
       i_product_name = product }
        when String.find product "AS" >= 0 ->
      `Server
 
-  | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = (3|4) } ->
+  | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = 4 } ->
      `Desktop
 
   (* For Windows (and maybe Linux in future, but it is not set now),
@@ -263,14 +263,6 @@ and get_ostype = function
  *   https://bugzilla.redhat.com/show_bug.cgi?id=1219857#c9
  *)
 and get_ovirt_osid = function
-  | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = 3;
-      i_arch = "i386" } ->
-    9
-
-  | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = 3;
-      i_arch = "x86_64" } ->
-    15
-
   | { i_type = "linux"; i_distro = ("rhel"|"centos"); i_major_version = 4;
       i_arch = "i386" } ->
     8


### PR DESCRIPTION
RHEL-3 isn't supported by v2v since commit 1ea99fb2a7aee63aabe02aa40e94297f7ad4f173. Remove some leftover code.

First commit potentially affects RHEL-4 too, but that would have been broken by my earlier patch to switch from rpm to yum for package removal (yum is not in RHEL-4 AFAICT)