### PR TITLE
Add new virt-v2v-show-roots tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Makefile.in
 /docs/virt-v2v-release-notes-2.4.1
 /docs/virt-v2v-release-notes-2.6.1
 /docs/virt-v2v-release-notes-2.8.1
+/docs/virt-v2v-show-roots.1
 /docs/virt-v2v-support.1
 /.gitattributes
 /.git-module-status
@@ -97,6 +98,8 @@ Makefile.in
 /podwrapper.pl
 /po/*.gmo
 /run
+/show-roots/.depend
+/show-roots/virt-v2v-show-roots
 /stamp-h1
 /test-data/blank-disks/blank-disk-*
 /test-data/fake-virtio-win/cd

--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ SUBDIRS += convert
 SUBDIRS += v2v
 SUBDIRS += inspector
 SUBDIRS += in-place
+SUBDIRS += show-roots
 
 SUBDIRS += tests
 
@@ -116,7 +117,8 @@ po/POTFILES: configure.ac
 po/POTFILES-ml: configure.ac
 	rm -f $@ $@-t
 	cd $(srcdir); \
-	find common/ml* lib in-place input inspector output v2v -name '*.ml' | \
+	find common/ml* lib in-place input inspector output show-roots v2v \
+	    -name '*.ml' | \
 	grep -v '^common/mlprogress/' | \
 	grep -v '^common/mlvisit/' | \
 	grep -v '^lib/config.ml$$' | \

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,7 @@ AC_CONFIG_FILES([Makefile
                  po-docs/ja/Makefile
                  po-docs/uk/Makefile
                  po/Makefile
+                 show-roots/Makefile
                  test-data/Makefile
                  test-data/binaries/Makefile
                  test-data/blank-disks/Makefile

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -34,6 +34,7 @@ EXTRA_DIST = \
 	virt-v2v-release-notes-2.4.pod \
 	virt-v2v-release-notes-2.6.pod \
 	virt-v2v-release-notes-2.8.pod \
+	virt-v2v-show-roots.pod \
 	virt-v2v-support.pod \
 	vm-generation-id-across-hypervisors.txt
 
@@ -55,6 +56,7 @@ man_MANS = \
 	virt-v2v-release-notes-2.4.1 \
 	virt-v2v-release-notes-2.6.1 \
 	virt-v2v-release-notes-2.8.1 \
+	virt-v2v-show-roots.1 \
 	virt-v2v-support.1
 
 noinst_DATA = \
@@ -73,6 +75,7 @@ noinst_DATA = \
 	$(top_builddir)/website/virt-v2v-release-notes-2.4.1.html \
 	$(top_builddir)/website/virt-v2v-release-notes-2.6.1.html \
 	$(top_builddir)/website/virt-v2v-release-notes-2.8.1.html \
+	$(top_builddir)/website/virt-v2v-show-roots.1.html \
 	$(top_builddir)/website/virt-v2v-support.1.html
 
 virt-v2v.1 $(top_builddir)/website/virt-v2v.1.html: stamp-virt-v2v.pod
@@ -239,6 +242,18 @@ stamp-virt-v2v-release-notes-2.8.pod: virt-v2v-release-notes-2.8.pod
 	$(PODWRAPPER) \
 	  --man virt-v2v-release-notes-2.8.1 \
 	  --html $(top_builddir)/website/virt-v2v-release-notes-2.8.1.html \
+	  --license GPLv2+ \
+	  --warning safe \
+	  $<
+	touch $@
+
+virt-v2v-show-roots.1 $(top_builddir)/website/virt-v2v-show-roots.1.html: stamp-virt-v2v-show-roots.pod
+
+stamp-virt-v2v-show-roots.pod: virt-v2v-show-roots.pod
+	$(PODWRAPPER) \
+	  --man virt-v2v-show-roots.1 \
+	  --html $(top_builddir)/website/virt-v2v-show-roots.1.html \
+	  --path $(top_srcdir)/common/options \
 	  --license GPLv2+ \
 	  --warning safe \
 	  $<

--- a/docs/virt-v2v-show-roots.pod
+++ b/docs/virt-v2v-show-roots.pod
@@ -1,0 +1,202 @@
+=head1 NAME
+
+virt-v2v-show-roots - Show roots for multi-boot guest
+
+=head1 SYNOPSIS
+
+ virt-v2v-show-roots [-i* options]
+                     guest
+                     [-O output.xml]
+
+=head1 DESCRIPTION
+
+Virt-v2v-show-roots is a companion tool for L<virt-v2v(1)> and
+L<virt-v2v-inspector(1)> which can be used before conversion to show
+the roots in a dual- or multi-boot guest.  (For a normal, single boot
+guest it will also work, showing one root.)  This allows you to make
+an informed choice for the virt-v2v I<--root> option.  You can follow
+that by running virt-v2v-inspector to estimate how much space would be
+needed to convert that root, and if conversion of that root is
+possible.
+
+This manual page only documents the program options, not all of the
+I<-i*> options which are the same as virt-v2v.  You should read
+L<virt-v2v(1)> first.
+
+Note that L<virt-inspector(1)> can also be used for simple, local disk
+images.
+
+=head2 Selecting the input guest
+
+You can run virt-v2v-show-roots with the same I<-i*> options as
+virt-v2v.  (Don't use any I<-o*> options).  This will select the guest
+that you want to show roots for.
+
+For example:
+
+ virt-v2v-show-roots -i disk filename.img
+
+=head2 Output
+
+The output from this tool is an XML document.
+
+By default the output is written to stdout.  This is useful when using
+the program interactively.  However if you want to use this tool from
+another program it is better to send the output to a specific file
+using I<-O output.xml>
+
+The output is the same as L<virt-inspector(1)>.  This is just a short
+summary.  Please read the virt-inspector documentation for full
+information.
+
+ <?xml version='1.0'?>
+ <operatingsystems>
+   <operatingsystem>
+     <root>/dev/sda1</root>
+     ...
+     <product_name>Fedora release 40</product_name>
+     ...
+   </operatingsystem>
+   <operatingsystem>
+     <root>/dev/sdb1</root>
+     ...
+     <product_name>CentOS Linux release 7.9</product_name>
+     ...
+   </operatingsystem>
+ </operatingsystems>
+
+This lists the operating system(s) (a.k.a roots) found inside the VM.
+For a single-boot guest, only one E<lt>operatingsystemE<gt> will be
+listed.  For dual- or multi-boot guests, multiple choices will be
+shown.
+
+The E<lt>rootE<gt> is the root filesystem.  This may be used directly
+with the virt-v2v I<--root> parameter.
+
+The E<lt>product_nameE<gt> is the product name found inside the root
+filesystem.  Other fields of interest may be shown here as well.
+
+=head1 OPTIONS
+
+=over 4
+
+=item B<--help>
+
+Display help.
+
+=item B<-O> F<output.xml>
+
+Write the output to a file called F<output.xml>.
+
+=item B<-O ->
+
+Write the output to stdout.  This is also the default if the I<-O>
+option is omitted.
+
+=item B<-v>
+
+=item B<--verbose>
+
+Enable verbose messages for debugging.
+
+=item B<-V>
+
+=item B<--version>
+
+Display version number and exit.
+
+=item B<-x>
+
+Enable tracing of libguestfs API calls.
+
+=item B<-i> ...
+
+=item B<-ic> ...
+
+=item B<-if> ...
+
+=item B<-io> ...
+
+=item B<-ip> ...
+
+=item B<-it> ...
+
+All of the I<-i*> options supported by virt-v2v and also supported by
+virt-v2v-show-roots.
+
+=item B<--colors>
+
+=item B<--colours>
+
+=item B<--echo-keys>
+
+=item B<--key> ...
+
+=item B<--keys-from-stdin>
+
+=item B<--machine-readable>
+
+=item B<--machine-readable>=format
+
+=item B<-q>
+
+=item B<--quiet>
+
+=item B<--wrap>
+
+These options work in the same way as the equivalent virt-v2v options.
+
+=back
+
+=head1 FILES
+
+Files used are the same as for virt-v2v.  See L<virt-v2v(1)/FILES>.
+
+=head1 ENVIRONMENT VARIABLES
+
+Environment variables used are the same as for virt-v2v.  See
+L<virt-v2v(1)/ENVIRONMENT VARIABLES>.
+
+=head1 SEE ALSO
+
+L<virt-v2v(1)>,
+L<virt-p2v(1)>,
+L<virt-inspector(1)>,
+L<virt-v2v-inspector(1)>,
+L<guestfs(3)>,
+L<guestfish(1)>,
+L<qemu-img(1)>,
+L<nbdkit(1)>,
+L<http://libguestfs.org/>.
+
+=head1 AUTHORS
+
+Matthew Booth
+
+Cédric Bosdonnat
+
+Laszlo Ersek
+
+Tomáš Golembiovský
+
+Shahar Havivi
+
+Richard W.M. Jones
+
+Roman Kagan
+
+Mike Latimer
+
+Nir Soffer
+
+Pino Toscano
+
+Xiaodai Wang
+
+Ming Xie
+
+Tingting Zheng
+
+=head1 COPYRIGHT
+
+Copyright (C) 2009-2025 Red Hat Inc.

--- a/docs/virt-v2v.pod
+++ b/docs/virt-v2v.pod
@@ -824,6 +824,9 @@ Windows Recovery Console, certain attached DVD drives, and bugs in
 libguestfs inspection heuristics, can make a guest look like a
 multi-boot operating system.
 
+Either L<virt-inspector(1)> or L<virt-v2v-show-roots(1)> can be used
+to list the roots for a dual-boot or multi-boot VM.
+
 The default in virt-v2v E<le> 0.7.1 was S<I<--root single>>, which
 causes virt-v2v to die if a multi-boot operating system is found.
 
@@ -1784,9 +1787,11 @@ L<https://rwmj.wordpress.com/2015/09/18/importing-kvm-guests-to-ovirt-or-rhev/#c
 L<virt-p2v(1)>,
 L<virt-v2v-inspector(1)>,
 L<virt-v2v-in-place(1)>,
+L<virt-v2v-show-roots(1)>,
 L<virt-customize(1)>,
 L<virt-df(1)>,
 L<virt-filesystems(1)>,
+L<virt-inspector(1)>,
 L<virt-sparsify(1)>,
 L<virt-sysprep(1)>,
 L<virt-win-reg(1)>,

--- a/run.in
+++ b/run.in
@@ -71,6 +71,7 @@ chcon --reference=/tmp "$b/tmp" 2>/dev/null ||:
 prepend PATH "$b/v2v"
 prepend PATH "$b/in-place"
 prepend PATH "$b/inspector"
+prepend PATH "$b/show-roots"
 export PATH
 
 # This is a cheap way to find some use-after-free and uninitialized

--- a/show-roots/Makefile.am
+++ b/show-roots/Makefile.am
@@ -1,0 +1,126 @@
+# libguestfs virt-v2v-show-roots tool
+# Copyright (C) 2009-2025 Red Hat Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+include $(top_srcdir)/subdir-rules.mk
+
+EXTRA_DIST = \
+	$(SOURCES_MLI) \
+	$(SOURCES_ML) \
+	$(SOURCES_C)
+
+SOURCES_MLI = \
+	show_roots.mli
+
+SOURCES_ML = \
+	show_roots.ml
+
+SOURCES_C = \
+	dummy.c
+
+bin_PROGRAMS = virt-v2v-show-roots
+
+virt_v2v_show_roots_SOURCES = $(SOURCES_C)
+virt_v2v_show_roots_CPPFLAGS = \
+	-DCAML_NAME_SPACE \
+	-I. \
+	-I$(top_builddir) \
+	-I$(shell $(OCAMLC) -where) \
+	-I$(top_srcdir)/lib
+virt_v2v_show_roots_CFLAGS = \
+	-pthread \
+	$(WARN_CFLAGS) $(WERROR_CFLAGS) \
+	$(LIBGUESTFS_CFLAGS) \
+	$(LIBVIRT_CFLAGS)
+
+BOBJECTS = $(SOURCES_ML:.ml=.cmo)
+XOBJECTS = $(BOBJECTS:.cmo=.cmx)
+
+OCAMLPACKAGES = \
+	-package str,unix,guestfs,libvirt,nbd \
+	-I $(top_builddir)/common/utils/.libs \
+	-I $(top_builddir)/common/qemuopts/.libs \
+	-I $(top_builddir)/gnulib/lib/.libs \
+	-I $(top_builddir)/lib \
+	-I $(top_builddir)/input \
+	-I $(top_builddir)/common/mlstdutils \
+	-I $(top_builddir)/common/mlutils \
+	-I $(top_builddir)/common/mlgettext \
+	-I $(top_builddir)/common/mlpcre \
+	-I $(top_builddir)/common/mlxml \
+	-I $(top_builddir)/common/mltools \
+	-I $(top_builddir)/common/mlcustomize \
+	-I $(top_builddir)/common/mldrivers
+if HAVE_OCAML_PKG_GETTEXT
+OCAMLPACKAGES += -package gettext-stub
+endif
+
+OCAMLCLIBS = \
+	-pthread \
+	-lqemuopts \
+	$(LIBGUESTFS_LIBS) \
+	$(LIBVIRT_LIBS) \
+	$(LIBCRYPT_LIBS) \
+	$(LIBXML2_LIBS) \
+	$(JSON_C_LIBS) \
+	$(LIBOSINFO_LIBS) \
+	$(LIBINTL) \
+	$(LIBNBD_LIBS) \
+	-lgnu
+
+OCAMLFLAGS = $(OCAML_FLAGS) $(OCAML_WARN_ERROR) -ccopt '$(CFLAGS)'
+
+if !HAVE_OCAMLOPT
+OBJECTS = $(BOBJECTS)
+else
+OBJECTS = $(XOBJECTS)
+endif
+
+OCAMLLINKFLAGS = \
+	mlstdutils.$(MLARCHIVE) \
+	mlgettext.$(MLARCHIVE) \
+	mlpcre.$(MLARCHIVE) \
+	mlxml.$(MLARCHIVE) \
+	mlcutils.$(MLARCHIVE) \
+	mltools.$(MLARCHIVE) \
+	mllibvirt.$(MLARCHIVE) \
+	mlcustomize.$(MLARCHIVE) \
+	mldrivers.$(MLARCHIVE) \
+	mlv2vlib.$(MLARCHIVE) \
+	mlinput.$(MLARCHIVE) \
+	$(LINK_CUSTOM_OCAMLC_ONLY)
+
+virt_v2v_show_roots_DEPENDENCIES = \
+	$(OBJECTS) \
+	$(top_builddir)/input/mlinput.$(MLARCHIVE) \
+	$(top_builddir)/lib/mlv2vlib.$(MLARCHIVE) \
+	$(top_srcdir)/ocaml-link.sh
+virt_v2v_show_roots_LINK = \
+	$(top_srcdir)/ocaml-link.sh -cclib '$(OCAMLCLIBS)' -- \
+	  $(OCAMLFIND) $(BEST) $(OCAMLFLAGS) $(OCAMLPACKAGES) $(OCAMLLINKFLAGS) \
+	  $(OBJECTS) -o $@
+
+# Data directory.
+
+virttoolsdatadir = $(datadir)/virt-tools
+
+# Dependencies.
+.depend: \
+	$(srcdir)/*.mli \
+	$(srcdir)/*.ml \
+	$(filter %.ml,$(BUILT_SOURCES))
+	$(top_builddir)/ocaml-dep.sh $^
+-include .depend

--- a/show-roots/dummy.c
+++ b/show-roots/dummy.c
@@ -1,0 +1,2 @@
+/* Dummy source, to be used for OCaml-based tools with no C sources. */
+enum { foo = 1 };

--- a/show-roots/show_roots.ml
+++ b/show-roots/show_roots.ml
@@ -1,0 +1,324 @@
+(* virt-v2v-show-roots
+ * Copyright (C) 2009-2025 Red Hat Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *)
+
+open Printf
+open Unix
+
+open Std_utils
+open Tools_utils
+open Unix_utils
+open Common_gettext.Gettext
+open Getopt.OptionName
+
+open Types
+open Utils
+
+module G = Guestfs
+
+let rec main () =
+  let set_string_option_once optname optref arg =
+    match !optref with
+    | Some _ ->
+       error (f_"%s option used more than once on the command line") optname
+    | None ->
+       optref := Some arg
+  in
+
+  let output_file = ref None in
+  let set_output_file_option filename =
+    if filename = "-" then output_file := None
+    else output_file := Some filename
+  in
+
+  let input_conn = ref None in
+  let input_format = ref None in
+  let input_password = ref None in
+  let input_transport = ref None in
+  let input_options = ref [] in
+  let io_query = ref false in
+  let set_input_option_compat k v =
+    List.push_back input_options (k, v)
+  in
+  let set_input_option option =
+    if option = "?" then io_query := true
+    else (
+      let k, v = String.split "=" option in
+      set_input_option_compat k v
+    )
+  in
+
+  let input_mode = ref `Not_set in
+  let set_input_mode mode =
+    if !input_mode <> `Not_set then
+      error (f_"%s option used more than once on the command line") "-i";
+    match mode with
+    | "disk" | "local" -> input_mode := `Disk
+    | "libvirt" -> input_mode := `Libvirt
+    | "libvirtxml" -> input_mode := `LibvirtXML
+    | "ova" -> input_mode := `OVA
+    | "vmx" -> input_mode := `VMX
+    | s ->
+       error (f_"unknown -i option: %s") s
+  in
+
+  let echo_keys = ref false in
+  let set_echo_keys () = echo_keys := true in
+  let keys_from_stdin = ref false in
+  let set_keys_from_stdin () = keys_from_stdin := true in
+  let key_options = ref [] in
+  let add_key_option s = List.push_back key_options s in
+
+  let argspec = [
+    [ S 'i' ],       Getopt.String ("disk|libvirt|libvirtxml|ova|vmx", set_input_mode),
+                                    s_"Set input mode (default: libvirt)";
+    [ M"ic" ],       Getopt.String ("uri", set_string_option_once "-ic" input_conn),
+                                    s_"Libvirt URI";
+    [ M"if" ],       Getopt.String ("format", set_string_option_once "-if" input_format),
+                                    s_"Input format";
+    [ M"io" ],       Getopt.String ("option[=value]", set_input_option),
+                                    s_"Set option for input mode";
+    [ M"ip" ],       Getopt.String ("filename", set_string_option_once "-ip" input_password),
+                                    s_"Use password from file to connect to input hypervisor";
+    [ M"it" ],       Getopt.String ("transport", set_string_option_once "-it" input_transport),
+                                    s_"Input transport";
+    [ S 'O' ],       Getopt.String ("output.xml", set_output_file_option),
+                                    s_"Set the output filename";
+    [ L"echo-keys" ],Getopt.Unit set_echo_keys,
+                                    s_"Don’t turn off echo for passphrases";
+    [ L"keys-from-stdin" ], Getopt.Unit set_keys_from_stdin,
+                                    s_"Read passphrases from stdin";
+    [ L"key" ],      Getopt.String (s_"SELECTOR", add_key_option),
+                                    s_"Specify a LUKS key";
+  ] in
+
+  let args = ref [] in
+  let anon_fun s = List.push_front s args in
+  let usage_msg =
+    sprintf (f_"\
+%s: estimate disk space needed before virt-v2v conversion
+
+virt-v2v-inspector -i disk disk.img [-O output.xml]
+
+A short summary of the options is given below.  For detailed help please
+read the man page virt-v2v-inspector(1).
+")
+      prog in
+
+  let opthandle = create_standard_options argspec ~anon_fun ~key_opts:false
+                    ~machine_readable:true usage_msg in
+  Getopt.parse opthandle.getopt;
+
+  (* Print the version, easier than asking users to tell us. *)
+  debug "info: %s: %s %s (%s)"
+        prog Config.package_name Config.package_version_full
+        Config.host_cpu;
+
+  (* Print the libvirt version if debugging. *)
+  if verbose () then (
+    let major, minor, release = Libvirt_utils.libvirt_get_version () in
+    debug "info: libvirt version: %d.%d.%d" major minor release
+  );
+
+  (* Create the v2v directory to control conversion. *)
+  let v2vdir = create_v2v_directory () in
+
+  (* Dereference the arguments. *)
+  let args = List.rev !args in
+  let output_file = !output_file in
+  let input_conn = !input_conn in
+  let input_mode = !input_mode in
+  let input_transport =
+    match !input_transport with
+    | None -> None
+    | Some "ssh" -> Some `SSH
+    | Some "vddk" -> Some `VDDK
+    | Some transport ->
+       error (f_"unknown input transport ‘-it %s’") transport in
+  let echo_keys = !echo_keys in
+  let keys_from_stdin = !keys_from_stdin in
+  let key_options = !key_options in
+
+  (* No arguments and machine-readable mode?  Print out some facts
+   * about what this binary supports.
+   *)
+  (match args, machine_readable () with
+   | [], Some { pr } ->
+      pr "virt-v2v-show-roots\n";
+      pr "libguestfs-rewrite\n";
+      pr "colours-option\n";
+      pr "io\n";
+      pr "input:disk\n";
+      pr "input:libvirt\n";
+      pr "input:libvirtxml\n";
+      pr "input:ova\n";
+      pr "input:vmx\n";
+      exit 0
+   | _, _ -> ()
+  );
+
+  (* Get the input module. *)
+  let (module Input_module) =
+    match input_mode with
+    | `Disk -> (module Input_disk.Disk : Input.INPUT)
+    | `LibvirtXML -> (module Input_libvirt.LibvirtXML)
+    | `OVA -> (module Input_ova.OVA)
+    | `VMX -> (module Input_vmx.VMX)
+    | `Not_set | `Libvirt ->
+       match input_conn with
+       | None -> (module Input_libvirt.Libvirt_)
+       | Some orig_uri ->
+          let { Xml.uri_server = server; uri_scheme = scheme } =
+            try Xml.parse_uri orig_uri
+            with Invalid_argument msg ->
+              error (f_"could not parse '-ic %s'.  \
+                        Original error message was: %s")
+                orig_uri msg in
+
+          match server, scheme, input_transport with
+          | None, _, _
+            | Some "", _, _       (* Not a remote URI. *)
+
+            | Some _, None, _     (* No scheme? *)
+            | Some _, Some "", _ ->
+             (module Input_libvirt.Libvirt_)
+
+          (* vCenter over https. *)
+          | Some server, Some ("esx"|"gsx"|"vpx"), None ->
+             (module Input_vcenter_https.VCenterHTTPS)
+
+          (* vCenter or ESXi using nbdkit vddk plugin *)
+          | Some server, Some ("esx"|"gsx"|"vpx"), Some `VDDK ->
+             (module Input_vddk.VDDK)
+
+          (* Xen over SSH *)
+          | Some server, Some "xen+ssh", _ ->
+             (module Input_xen_ssh.XenSSH)
+
+          (* Old virt-v2v also supported qemu+ssh://.  However I am
+           * deliberately not supporting this in new virt-v2v.  Don't
+           * use virt-v2v if a guest already runs on KVM.
+           *)
+
+          (* Unknown remote scheme. *)
+          | Some _, Some _, _ ->
+             warning (f_"no support for remote libvirt connections \
+                         to '-ic %s'.  The conversion may fail when it \
+                         tries to read the source disks.") orig_uri;
+             (module Input_libvirt.Libvirt_) in
+
+  let input_options = {
+    Input.bandwidth = None;
+    input_conn = input_conn;
+    input_format = !input_format;
+    input_options = !input_options;
+    input_password = !input_password;
+    input_transport = input_transport;
+    (* This must always be true so that we do not modify the
+     * source.  This is set to [false] by in-place mode.
+     *)
+    read_only = true;
+  } in
+
+  (* If -io ? then we want to query input options supported in this mode. *)
+  if !io_query then (
+    Input_module.query_input_options ();
+    exit 0
+  );
+
+  (* Before starting the input module, check there is sufficient
+   * free space in the temporary directory on the host.
+   *)
+  check_host_free_space ();
+
+  (* Start the input module (runs an NBD server in the background). *)
+  message (f_"Setting up the source: %s")
+    (Input_module.to_string input_options args);
+  let source = Input_module.setup v2vdir input_options args in
+
+  message (f_"Running virt-inspector");
+
+  (* We're not really doing a conversion here, but write the 'convert'
+   * file around this to tune the input module correctly.
+   *)
+  with_open_out (v2vdir // "convert") (fun _ -> ());
+
+  (* Get the list of input sockets (NBD endpoints). *)
+  let add_params =
+    List.map (
+      fun { s_disk_id = i } ->
+        let socket = sprintf "nbd+unix://?socket=%s/in%d" v2vdir i in
+        sprintf "-a %s" (quote socket)
+    ) source.s_disks
+    |> String.concat " " in
+
+  (* Get the list of --key and related options and pass them through. *)
+  let key_params =
+    List.map (fun opt -> sprintf "--key %s" (quote opt)) key_options
+    |> String.concat " " in
+
+  (* Run virt-inspector. *)
+  let cmd = sprintf "virt-inspector --format=raw %s %s %s %s"
+              add_params key_params
+              (if echo_keys then "--echo-keys" else "")
+              (if keys_from_stdin then "--keys-from-stdin" else "") in
+  let xml_lines = external_command cmd in
+
+  unlink (v2vdir // "convert");
+
+  (* Debug the v2vdir. *)
+  if verbose () then (
+    let cmd = sprintf "ls -alZ %s 1>&2" (quote v2vdir) in
+    ignore (Sys.command cmd)
+  );
+
+  (* Dump out the available information. *)
+  let chan =
+    match output_file with
+    | None -> Stdlib.stdout
+    | Some filename -> open_out filename in
+  List.iter (fprintf chan "%s\n") xml_lines;
+  Stdlib.flush chan;
+
+  message (f_"Finishing off");
+  (* As the last thing, write a file indicating success before
+   * we exit (so before we kill the helpers).  The helpers may
+   * use the presence or absence of the file to determine if
+   * on-success or on-fail cleanup is required.
+   *)
+  with_open_out (v2vdir // "done") (fun _ -> ())
+
+(* Some input modules use large_tmpdir to unpack OVAs or store qcow2
+ * overlays and some output modules use it to store temporary files.
+ * In addition the  500 MB guestfs appliance may be created there.
+ * (RHBZ#1316479, RHBZ#2051394)
+ *)
+and check_host_free_space () =
+  let free_space = StatVFS.free_space (StatVFS.statvfs large_tmpdir) in
+  debug "check_host_free_space: large_tmpdir=%s free_space=%Ld"
+        large_tmpdir free_space;
+  if free_space < 1_073_741_824L then
+    error (f_"insufficient free space in the conversion server \
+              temporary directory %s (%s).\n\nEither free up space \
+              in that directory, or set the LIBGUESTFS_CACHEDIR \
+              environment variable to point to another directory \
+              with more than 1GB of free space.\n\nSee also the \
+              virt-v2v(1) manual, section \
+              \"Minimum free space check in the host\".")
+      large_tmpdir (human_size free_space)
+
+let () = run_main_and_handle_errors main

--- a/show-roots/show_roots.mli
+++ b/show-roots/show_roots.mli
@@ -1,0 +1,19 @@
+(* virt-v2v-show-roots
+ * Copyright (C) 2009-2025 Red Hat Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *)
+
+(* Nothing is exported. *)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -113,6 +113,8 @@ TESTS = \
 	test-print-source.sh \
 	test-reject-blank-disk.sh \
 	test-rhbz1232192.sh \
+	test-show-roots.sh \
+	test-show-roots-encrypted.sh \
 	test-sound.sh \
 	test-virtio-win-iso.sh \
 	test-windows-conversion.sh \
@@ -317,6 +319,8 @@ EXTRA_DIST += \
 	test-phony-winxp-32-ls.txt \
 	test-reject-blank-disk.sh \
 	test-rhbz1232192.sh \
+	test-show.sh \
+	test-show-roots-encrypted.sh \
 	test-sound.sh \
 	test-trim.sh \
 	test-virtio-win-iso.sh \

--- a/tests/test-show-roots-encrypted.sh
+++ b/tests/test-show-roots-encrypted.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -
+# libguestfs virt-v2v test script
+# Copyright (C) 2014-2025 Red Hat Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Test virt-v2v-show-roots with an encrypted guest.
+
+unset CDPATH
+export LANG=C
+set -e
+
+source ./functions.sh
+set -e
+set -x
+
+skip_if_skipped
+f=../test-data/phony-guests/fedora-luks-on-lvm.img
+requires test -f $f
+
+d=$PWD/test-show-roots-encrypted.d
+rm -rf $d
+cleanup_fn rm -r $d
+mkdir $d
+
+out="$d/out"
+
+keys=(--key /dev/Volume-Group/Root:key:FEDORA-Root
+      --key /dev/Volume-Group/Logical-Volume-1:key:FEDORA-LV1
+      --key /dev/Volume-Group/Logical-Volume-2:key:FEDORA-LV2
+      --key /dev/Volume-Group/Logical-Volume-3:key:FEDORA-LV3)
+
+$VG virt-v2v-show-roots --debug-gc -i disk $f "${keys[@]}" -O $out
+cat $out
+
+# Expect certain elements to be present.
+grep '^<operatingsystems>' $out
+grep '<operatingsystem>' $out
+grep '<root>/dev/mapper/luks-' $out
+grep '<distro>fedora</distro>' $out
+grep '<osinfo>fedora14</osinfo>' $out

--- a/tests/test-show-roots.sh
+++ b/tests/test-show-roots.sh
@@ -1,0 +1,75 @@
+#!/bin/bash -
+# libguestfs virt-v2v test script
+# Copyright (C) 2014-2025 Red Hat Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Test virt-v2v-show-roots.
+
+unset CDPATH
+export LANG=C
+set -e
+
+source ./functions.sh
+set -e
+set -x
+
+skip_if_skipped
+requires test -s ../test-data/phony-guests/windows.img
+
+img="$abs_top_builddir/test-data/phony-guests/windows.img"
+
+export VIRT_TOOLS_DATA_DIR="$srcdir/../test-data/fake-virt-tools"
+export VIRTIO_WIN="$srcdir/../test-data/fake-virtio-win/drivers"
+
+d=$PWD/test-show-roots.d
+rm -rf $d
+cleanup_fn rm -r $d
+mkdir $d
+
+out="$d/out"
+
+libvirt_xml="$d/test.xml"
+rm -f $libvirt_xml
+n=windows
+cat > $libvirt_xml <<EOF
+<node>
+  <domain type='test'>
+    <name>$n</name>
+    <memory>1048576</memory>
+    <os>
+      <type>hvm</type>
+      <boot dev='hd'/>
+    </os>
+    <devices>
+      <disk type='file' device='disk'>
+        <driver name='qemu' type='raw'/>
+        <source file='$img'/>
+        <target dev='vda' bus='virtio'/>
+      </disk>
+    </devices>
+  </domain>
+</node>
+EOF
+
+$VG virt-v2v-show-roots --debug-gc -i libvirt -ic "test://$libvirt_xml" $n -O $out
+cat $out
+
+# Expect certain elements to be present.
+grep '^<operatingsystems>' $out
+grep '<operatingsystem>' $out
+grep '<root>/dev/sda2</root>' $out
+grep '<distro>windows</distro>' $out
+grep '<osinfo>win2k22</osinfo>' $out


### PR DESCRIPTION
This can be used to list out all roots inside a virtual machine, allowing tools built on top of virt-v2v to offer sensible choices for the virt-v2v --root option.

Suggested-by: Martin Necas
Fixes: https://issues.redhat.com/browse/RHEL-88985