### PR TITLE
convert: Use e2fsck -n flag when checking ext2/3/4 filesystems

### DIFF
--- a/convert/convert.ml
+++ b/convert/convert.ml
@@ -258,7 +258,7 @@ and do_fsck g =
          );
 
       | dev, "ext4" ->
-         g#e2fsck dev (* ~correct:false is the default *)
+         g#e2fsck ~forceno:true dev
 
       | dev, "xfs" ->
          if g#xfs_repair ~nomodify:true dev <> 0 then

--- a/m4/guestfs-libraries.m4
+++ b/m4/guestfs-libraries.m4
@@ -21,7 +21,8 @@ dnl Of course we need libguestfs.
 dnl
 dnl We need libguestfs 1.55.6 for guestfs_sh_out.
 dnl We need libguestfs 1.55.12 for guestfs_btrfs_scrub_full.
-PKG_CHECK_MODULES([LIBGUESTFS], [libguestfs >= 1.55.12])
+dnl We need libguestfs 1.55.13 for guestfs_e2fsck FORCENO flag.
+PKG_CHECK_MODULES([LIBGUESTFS], [libguestfs >= 1.55.13])
 printf "libguestfs version is "; $PKG_CONFIG --modversion libguestfs
 
 dnl And libnbd.


### PR DESCRIPTION
When checking the fedora-30 image from virt-builder:
```
  $ virt-v2v -i disk fedora-30.img -o null
  ...
  [  68.4] Checking filesystem integrity before conversion
  virt-v2v: error: libguestfs error: e2fsck: e2fsck 1.47.1 (20-May-2024)
  e2fsck: need terminal for interactive repairs
```
Use the e2fsck -n flag to avoid this problem.

This flag is described as:
```
  -n  Open  the  file system read-only, and assume an answer of `no' to
      all questions.  Allows e2fsck to be used non-interactively.  This
      option may not be specified at the same time as the -p or -y  op‐
      tions.
```
Updates: commit 78ffb68d4f1ef8af776c24537feaf832fd3ec7e9
Updates: https://issues.redhat.com/browse/RHEL-91931