### PR TITLE
-o libvirt: use inspected osinfo short-id for libvirt XML annotation

### DIFF
--- a/tests/test-windows-phony.sh
+++ b/tests/test-windows-phony.sh
@@ -82,3 +82,9 @@ mktest "inspect-get-osinfo /dev/sda2" "$osinfo_name"
 
 guestfish --ro -a "$d/$guestname-sda" -i < "$script" > "$response"
 diff -u "$expected" "$response"
+
+# host osinfo-db may be too old for win2k25
+if [ $osinfo_name != "win2k25" ] ; then
+    # Sanity check that _some_ osinfo annotation ends up in XML
+    grep -q "libosinfo:os id='http://microsoft.com/win/" $d/$guestname.xml
+fi


### PR DESCRIPTION
Current code manually tries to assemble the full osinfo ID string
from type+distro+version info. But inspection already gives us
osinfo short-id. Use that to look up the osinfo OS class which
can give us the full ID string directly.
    
One caveat: inspected osinfo short-id is not actually validated
against the installed host osinfo-db. For example, we might
correctly inspect the guest as win2k25 even when host osinfo-db
is too old and does not contain win2k25. -o libvirt then has
nothing to query, so XML will be generated without any libosinfo
data in it.
