### PR TITLE
Remove noextents option, add nbdkit-count-filter

### DIFF
--- a/README
+++ b/README
@@ -69,6 +69,7 @@ REQUIREMENTS
   + nbdkit-vddk-plugin
 
   + nbdkit-blocksize-filter
+  + nbdkit-count-filter
   + nbdkit-cow-filter
   + nbdkit-multi-conn-filter
   + nbdkit-rate-filter

--- a/README
+++ b/README
@@ -71,7 +71,6 @@ REQUIREMENTS
   + nbdkit-blocksize-filter
   + nbdkit-cow-filter
   + nbdkit-multi-conn-filter
-  + nbdkit-noextents-filter
   + nbdkit-rate-filter
   + nbdkit-retry-filter
 

--- a/input/input_vddk.ml
+++ b/input/input_vddk.ml
@@ -313,6 +313,13 @@ See also the virt-v2v-input-vmware(1) manual.") libNN
        *)
       Nbdkit.add_filter_if_available cmd "retry";
 
+      (* Add the count filter if available, to report bytes read.
+       * Since it writes a debug message, only do this if verbose.
+       * This should be close to the plugin so we're reporting what
+       * is read over the wire.
+       *)
+      if verbose () then Nbdkit.add_filter_if_available cmd "count";
+
       (* Split very large requests to avoid out of memory errors on the
        * server.  Since we're using this filter, also add minblock=512
        * although it will make no difference.

--- a/input/input_vddk.ml
+++ b/input/input_vddk.ml
@@ -58,7 +58,6 @@ All other settings are optional:
   -io vddk-file=FILE           Override nbdkit-vddk-plugin file= parameter
   -io vddk-libdir=LIBDIR       VDDK library parent directory
   -io vddk-nfchostport=PORT    VDDK nfchostport
-  -io vddk-noextents=true      Avoid slow VDDK QueryAllocatedBlocks API
   -io vddk-port=PORT           VDDK port
   -io vddk-snapshot=SNAPSHOT-MOREF
                                VDDK snapshot moref
@@ -79,7 +78,6 @@ information on these settings.
         "file";
         "libdir";
         "nfchostport";
-        "noextents";
         "port";
         "snapshot";
         "thumbprint";
@@ -208,9 +206,6 @@ information on these settings.
       try Some (List.assoc "libdir" io_options) with Not_found -> None in
     let nfchostport =
       try Some (List.assoc "nfchostport" io_options) with Not_found -> None in
-    let noextents =
-      try bool_of_string (List.assoc "noextents" io_options)
-      with Not_found -> false in
     let port =
       try Some (List.assoc "port" io_options) with Not_found -> None in
     let snapshot =
@@ -317,36 +312,6 @@ See also the virt-v2v-input-vmware(1) manual.") libNN
        * interruptions in service.  It must be closest to the plugin.
        *)
       Nbdkit.add_filter_if_available cmd "retry";
-
-      (* VDDK's QueryAllocatedBlocks API is infamously slow.  It appears
-       * to block all other requests while it is running.  This API is
-       * also only called during the copy phase, not during conversion
-       * (or if it is, extremely rarely).
-       *
-       * If fstrim was successful, then trimmed blocks are stored in
-       * the COW filter (see below), and so requests for extents stop
-       * at that layer.  However for areas of the disk that fstrim
-       * thinks contain data, we still have to go through to VDDK to
-       * fetch extents.
-       *
-       * We could therefore add nbdkit-noextents-filter here (below COW,
-       * above VDDK plugin) which stops extents requests from going
-       * to VDDK, which would stop QueryAllocatedBlocks ever being
-       * called.  In my testing this is a moderate performance win.
-       *
-       * However ... in the case where fstrim failed, or for filesystems
-       * or partitions on the disk that we don't understand, doing this
-       * would mean that those are copied completely, as there would be
-       * no extent data (nbdcopy will still sparsify them on the target,
-       * but we'd have to copy all the bits from VMware).  Because
-       * here we don't know if this is the case, be conservative and
-       * actually don't use this filter.
-       *
-       * If used, this filter should be close to the plugin and MUST
-       * be below the COW filter.
-       *)
-      if noextents then
-        Nbdkit.add_filter_if_available cmd "noextents";
 
       (* Split very large requests to avoid out of memory errors on the
        * server.  Since we're using this filter, also add minblock=512

--- a/input/nbdkit_curl.ml
+++ b/input/nbdkit_curl.ml
@@ -58,6 +58,13 @@ let create_curl ?bandwidth ?cookie_script ?cookie_script_renew ?cor
    *)
   Nbdkit.add_filter_if_available cmd "retry";
 
+  (* Add the count filter if available, to report bytes read.
+   * Since it writes a debug message, only do this if verbose.
+   * This should be close to the plugin so we're reporting what
+   * is read over the wire.
+   *)
+  if verbose () then Nbdkit.add_filter_if_available cmd "count";
+
   (* IMPORTANT! Add the COW filter.  It must be furthest away
    * except for the rate filter.
    *)

--- a/input/nbdkit_ssh.ml
+++ b/input/nbdkit_ssh.ml
@@ -54,6 +54,13 @@ let create_ssh ?bandwidth ?cor ?(retry=true)
   if retry then
     Nbdkit.add_filter_if_available cmd "retry";
 
+  (* Add the count filter if available, to report bytes read.
+   * Since it writes a debug message, only do this if verbose.
+   * This should be close to the plugin so we're reporting what
+   * is read over the wire.
+   *)
+  if verbose () then Nbdkit.add_filter_if_available cmd "count";
+
   (* IMPORTANT! Add the COW filter.  It must be furthest away
    * except for the rate filter.
    *)

--- a/output/output.ml
+++ b/output/output.ml
@@ -98,6 +98,7 @@ let output_to_local_file ?(changeuid = fun f -> f ()) ?(compressed = false)
        let cmd = Nbdkit.create "file" in
        Nbdkit.add_arg cmd "file" filename;
        Nbdkit.add_arg cmd "cache" "none";
+       if verbose () then Nbdkit.add_filter_if_available cmd "count";
        let _, pid = Nbdkit.run_unix socket cmd in
        pid
 
@@ -197,6 +198,7 @@ let create_local_output_disks dir
     let cmd = Nbdkit.create "file" in
     Nbdkit.add_arg cmd "dir" output_storage;
     Nbdkit.add_arg cmd "cache" "none";
+    if verbose () then Nbdkit.add_filter_if_available cmd "count";
     let _, pid = Nbdkit.run_unix socket cmd in
     On_exit.kill pid;
 


### PR DESCRIPTION
Two trivial changes to virt-v2v.  The second one will help with troublesome debugging such as the one we recently had with a customer.

The two changes aren't related, but they touch adjacent areas of the code so combining them as one series avoids awkward merge conflicts.

@crobinso 