### PR TITLE
output: kubevirt: Add bootOrder to Kubevirt YAML

### DIFF
--- a/tests/test-o-kubevirt-fedora.yaml.expected
+++ b/tests/test-o-kubevirt-fedora.yaml.expected
@@ -26,6 +26,7 @@ spec:
           disks:
           - disk:
               bus: virtio
+            bootOrder: 1
             name: disk-0
       volumes:
       - hostDisk:

--- a/tests/test-o-kubevirt-windows.yaml.expected
+++ b/tests/test-o-kubevirt-windows.yaml.expected
@@ -36,6 +36,7 @@ spec:
           disks:
           - disk:
               bus: virtio
+            bootOrder: 1
             name: disk-0
           interfaces:
           - name: net_default


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHEL-110742