### PR TITLE
convert: tighten permissions on windows /Program Files/Guestfs

### DIFF
--- a/convert/convert.ml
+++ b/convert/convert.ml
@@ -130,6 +130,9 @@ let rec convert input_disks options source =
 
   g#umount_all ();
 
+  (* Post-conversion steps that run with filesystems unmounted *)
+  do_post_convert g inspect;
+
   (* Doing fstrim on all the filesystems reduces the transfer size
    * because unused blocks are marked in the overlay and thus do
    * not have to be copied.
@@ -227,6 +230,13 @@ and check_guest_free_space inspect mpstats =
                   filesystem ‘%s’.  %Ld inodes available < %Ld inodes needed")
           mp_path ffree needed_inodes
   ) mpstats
+
+(* Run OS specific post-conversion steps that run with filesystems unmounted *)
+and do_post_convert g inspect =
+  match inspect.i_type with
+  | "windows" -> Convert_windows.post_convert g inspect
+  | _ -> () (* No post-convert for other OS types *)
+
 
 (* Perform the fstrim. *)
 and do_fstrim g inspect =

--- a/convert/convert_windows.ml
+++ b/convert/convert_windows.ml
@@ -984,3 +984,13 @@ if errorlevel 3010 exit /b 0
   in
 
   do_convert ()
+
+(* Post-conversion steps that run with filesystems unmounted *)
+let post_convert (g : G.guestfs) inspect =
+  (* Lock down firstboot dir permissions for windows guests *)
+  message (f_"Fixing NTFS permissions");
+  let path = "/Program Files/Guestfs" in
+  debug "info: fixing NTFS permissions on %s" path;
+  try g#ntfs_chmod inspect.i_root 0o755 path ~recursive:true
+  with G.Error msg ->
+    warning (f_"ntfs_chmod on %s failed: %s") path msg

--- a/convert/convert_windows.mli
+++ b/convert/convert_windows.mli
@@ -24,3 +24,5 @@ val convert : Guestfs.guestfs -> Types.source -> Types.inspect ->
               Firmware.i_firmware -> Types.guestcaps_block_type ->
               bool -> Types.static_ip list ->
               Types.guestcaps
+
+val post_convert : Guestfs.guestfs -> Types.inspect -> unit

--- a/m4/guestfs-libraries.m4
+++ b/m4/guestfs-libraries.m4
@@ -19,8 +19,8 @@ dnl Any C libraries required by virt-v2v.
 
 dnl Of course we need libguestfs.
 dnl
-dnl We need libguestfs 1.57.1 for guestfs_setfiles.
-PKG_CHECK_MODULES([LIBGUESTFS], [libguestfs >= 1.57.1])
+dnl We need libguestfs 1.57.3 for guestfs_ntfs_chmod.
+PKG_CHECK_MODULES([LIBGUESTFS], [libguestfs >= 1.57.3])
 printf "libguestfs version is "; $PKG_CONFIG --modversion libguestfs
 
 dnl And libnbd.


### PR DESCRIPTION
By default these files are created 777 equivalent permissions. That apparently upsets some windows security auditing tools.

Use the new ntfs_chmod API to make the whole tree 755.

Fixes: https://issues.redhat.com/browse/RHEL-104352

Requires this libguestfs PR: https://github.com/libguestfs/libguestfs/pull/213

@rjones this works but is not complete. I need some advice.
* This is in `convert.ml` but  `convert_windows.ml` would make more sense. But ntfs_chmod needs to operate on unmounted filesystem. So I'd need to plug an unmount_all and filesystem remount into `convert_windows.ml` which seems awkward. Suggestions?
* `Program Files` could be on a different drive than the inspection root. How can I identify that?