### PR TITLE
Add Cinder AZ support for OpenStack output using -oo parameter

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -101,6 +101,7 @@ TESTS = \
 	test-o-local-qcow2-compressed.sh \
 	test-o-null.sh \
 	test-o-openstack.sh \
+	test-o-openstack-oo-az.sh \
 	test-o-ovirt-upload-oo-query.sh \
 	test-o-ovirt-upload.sh \
 	test-o-ovirt.sh \


### PR DESCRIPTION
Some OpenStack clouds require an availability zone to be set when creating a volume. This PR adds an availability-zone -oo parameter to the OpenStack output to allow defining the availability zone for volume creation. 

An issue with unquoted parameter values containing spaces in generated OpenStack CLI calls was also found while testing this and resolved.