### PR TITLE
added --no-fstrim option to disable fstrim during conversion

### DIFF
--- a/convert/convert.ml
+++ b/convert/convert.ml
@@ -40,6 +40,7 @@ type options = {
   smp : int option;
   static_ips : static_ip list;
   customize_ops : Customize_cmdline.ops;
+  no_fstrim : bool;
 }
 
 (* Mountpoint stats, used for free space estimation. *)
@@ -156,8 +157,11 @@ let rec convert input_disks options source =
    * because unused blocks are marked in the overlay and thus do
    * not have to be copied.
    *)
-  message (f_"Mapping filesystem data to avoid copying unused and blank areas");
-  do_fstrim g inspect;
+  if not options.no_fstrim then (
+    message (f_"Mapping filesystem data to avoid copying unused and blank areas");
+    do_fstrim g inspect
+  ) else
+    message (f_"Skipping fstrim (--no-fstrim specified)");
 
   (* Check (fsck) the filesystems after conversion. *)
   g#umount_all ();

--- a/convert/convert.mli
+++ b/convert/convert.mli
@@ -26,6 +26,7 @@ type options = {
   smp : int option;                (** [--smp] option *)
   static_ips : Types.static_ip list; (** [--mac :ip:] option *)
   customize_ops : Customize_cmdline.ops; (** virt-customize options *)
+  no_fstrim : bool;                (** [--no-fstrim] option *)
 }
 (** Command line options that get passed through to the conversion code. *)
 

--- a/in-place/in_place.ml
+++ b/in-place/in_place.ml
@@ -151,6 +151,7 @@ let rec main () =
   let set_root_choice = Types.set_root_choice root_choice in
 
   (* Other options that we handle here. *)
+  let no_fstrim = ref false in
   let print_source = ref false in
 
   let input_modes =
@@ -185,6 +186,8 @@ let rec main () =
                                     s_"Map network ‘in’ to ‘out’";
     [ S 'O' ],       Getopt.String ("output.xml", set_output_xml_option),
                                     s_"Set the output filename";
+    [ L"no-fstrim" ],  Getopt.Set no_fstrim,
+                                    s_"Don't trim filesystems before conversion";
     [ L"print-source" ], Getopt.Set print_source,
                                     s_"Print source and stop";
     [ L"root" ],     Getopt.String ("ask|... ", set_root_choice),
@@ -254,6 +257,7 @@ read the man page virt-v2v-in-place(1).
   let customize_ops = get_customize_ops () in
   let input_conn = !input_conn in
   let input_mode = !input_mode in
+  let no_fstrim = !no_fstrim in
   let memsize = !memsize in
   let output_xml = !output_xml in
   let print_source = !print_source in
@@ -326,6 +330,7 @@ read the man page virt-v2v-in-place(1).
     smp;
     static_ips;
     customize_ops;
+    no_fstrim;
   } in
 
   (* Before starting the input module, check there is sufficient

--- a/inspector/inspector.ml
+++ b/inspector/inspector.ml
@@ -293,6 +293,7 @@ read the man page virt-v2v-inspector(1).
     smp;
     static_ips;
     customize_ops;
+    no_fstrim = false;
   } in
 
   (* Before starting the input module, check there is sufficient

--- a/v2v/v2v.ml
+++ b/v2v/v2v.ml
@@ -440,6 +440,7 @@ read the man page virt-v2v(1).
     smp;
     static_ips;
     customize_ops;
+    no_fstrim = false;
   } in
 
   (* Before starting the input module, check there is sufficient


### PR DESCRIPTION
## What this PR does / why we need it
This PR adds a new `--no-fstrim` flag to `virt-v2v-in-place` that allows skipping the filesystem trimming operation during VM conversion. When enabled, the conversion process completes more quickly by avoiding the time-consuming fstrim operation on guest filesystems.

The flag is particularly useful in scenarios where:

- The copy phase is not applicable (as with `virt-v2v-in-place`)
- Post-conversion tasks can be handled directly on the guest
- Faster conversion is prioritized over filesystem optimization

This is an optional flag that defaults to running fstrim to maintain backward compatibility.

## Testing done
Built and tested the patched RPM locally on Fedora
Verified the `--no-fstrim` flag is properly parsed and passed to the conversion logic
Confirmed that when the flag is used, fstrim operations are skipped during conversion
Verified backward compatibility - without the flag, normal fstrim behavior is preserved

Without the flag 
<img width="1866" height="434" alt="image" src="https://github.com/user-attachments/assets/3dd7bca5-e92a-42d7-8cca-75e6effde267" />

With the flag 
<img width="2880" height="152" alt="image" src="https://github.com/user-attachments/assets/a0df1c47-fb3b-4b98-b167-39124dad805b" />
