### PR TITLE
output: sanitize '/' in libvirt-derived names

### DIFF
--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -289,3 +289,8 @@ let name_from_disk disk =
   if name = "" then
     error (f_"invalid input filename (%s)") disk;
   name
+
+(* Replace '/' with '_' in guest names for filesystem paths and
+ * libvirt domain names. *)
+let sanitize_slash s =
+  String.map (fun c -> if c = '/' then '_' else c) s

--- a/lib/utils.mli
+++ b/lib/utils.mli
@@ -108,3 +108,7 @@ val name_from_disk : string -> string
 (** Take a disk name and derive from it a suitable source name.
 
     Used in particular by [-i disk], [-i ova] and [-i vmx] modes. *)
+
+val sanitize_slash : string -> string
+(** Replace '/' with '_' in guest names for filesystem paths and
+    libvirt domain names. *)

--- a/output/create_libvirt_xml.ml
+++ b/output/create_libvirt_xml.ml
@@ -51,7 +51,7 @@ let create_libvirt_xml ?pool source inspect
 
   List.push_back_list body [
     Comment generated_by;
-    e "name" [] [PCData output_name];
+    e "name" [] [PCData (Utils.sanitize_slash output_name)];
   ];
 
   (match source.s_genid with

--- a/output/output.ml
+++ b/output/output.ml
@@ -150,8 +150,12 @@ let output_to_local_file ?name
          ignore (waitpid [] pid)
      )
 
+let disk_name name i =
+  let name = Utils.sanitize_slash name in
+  sprintf "%s-sd%s" name (drive_name i)
+
 let disk_path os name i =
-  let outdisk = sprintf "%s/%s-sd%s" os name (drive_name i) in
+  let outdisk = sprintf "%s/%s" os (disk_name name i) in
   absolute_path outdisk
 
 let create_local_output_disks dir
@@ -214,7 +218,7 @@ let create_local_output_disks dir
     let uris =
       List.mapi (
         fun i _ ->
-          let export = sprintf "%s-sd%s" output_name (drive_name i) in
+          let export = disk_name output_name i in
           NBD_URI.Unix (socket, Some export)
       ) input_disks in
 

--- a/output/output.mli
+++ b/output/output.mli
@@ -121,6 +121,10 @@ val output_to_local_file : ?name:string ->
     (such as unmounting a host filesystem or removing a host device)
     depends on the NBD server releasing resources. *)
 
+val disk_name : string -> int -> string
+(** Return the sanitized disk name for the i'th disk,
+    eg. 0 => name-sda. *)
+
 val disk_path : string -> string -> int -> string
 (** For [-o disk|qemu], return the output disk name of the i'th disk,
     eg. 0 => /path/to/name-sda. *)

--- a/output/output_disk.ml
+++ b/output/output_disk.ml
@@ -105,7 +105,7 @@ module Disk = struct
                 (disk_path output_storage output_name)
                 output_format output_name in
 
-    let file = output_storage // output_name ^ ".xml" in
+    let file = output_storage // (sanitize_slash output_name) ^ ".xml" in
     with_open_out file (fun chan -> DOM.doc_to_chan chan doc);
 
     if verbose () then (

--- a/output/output_kubevirt.ml
+++ b/output/output_kubevirt.ml
@@ -146,7 +146,7 @@ module Kubevirt = struct
     let doc = create_kubevirt_yaml source inspect target_meta disk_path
                 output_format output_name in
 
-    let file = output_storage // output_name ^ ".yaml" in
+    let file = output_storage // (sanitize_slash output_name) ^ ".yaml" in
     with_open_out file (fun chan -> YAML.doc_to_chan chan doc);
 
     if verbose () then (

--- a/output/output_libvirt.ml
+++ b/output/output_libvirt.ml
@@ -189,7 +189,7 @@ module Libvirt_ = struct
     let doc =
       create_libvirt_xml ~pool:pool_name source inspect target_meta
         target_features domcaps_features
-        (fun i -> output_name ^ "-sd" ^ (drive_name i))
+        (disk_name output_name)
         output_format output_name in
 
     let tmpfile, chan = Filename.open_temp_file "v2vlibvirt" ".xml" in

--- a/output/output_openstack.ml
+++ b/output/output_openstack.ml
@@ -322,7 +322,7 @@ The os-* parameters and environment variables are optional.
          * something related to the guest name.  Cinder volume
          * names do not need to be unique.
          *)
-        let name = sprintf "%s-sd%s" output_name (drive_name i) in
+        let name = disk_name output_name i in
 
         (* Create the cinder volume. *)
         let id = create_cinder_volume name description size in

--- a/output/output_qemu.ml
+++ b/output/output_qemu.ml
@@ -111,7 +111,7 @@ module QEMU = struct
     (* Start the shell script.  Write it to a temporary file
      * which we rename at the end.
      *)
-    let file = output_storage // output_name ^ ".sh" in
+    let file = output_storage // (sanitize_slash output_name) ^ ".sh" in
     let tmpfile = file ^ ".tmp" in
     On_exit.unlink tmpfile;
 


### PR DESCRIPTION
Libvirt volume and filename derivation must not include '/' characters, since they are interpreted as path separators.

Introduce a small helper to sanitize guest-derived strings by replacing '/' with '_', ensuring generated filenames and volume names remain valid and predictable.

Only '/' is handled here, as other characters are already accepted by libvirt storage backends and filesystems.