### PR TITLE
input: use parse_uri_raw for VMX SSH URIs to preserve %2f

### DIFF
--- a/input/parse_domain_from_vmx.ml
+++ b/input/parse_domain_from_vmx.ml
@@ -39,7 +39,7 @@ let vmx_source_of_arg input_password input_transport arg =
   | None, arg -> VMXSourceFile arg
   | Some `SSH, arg ->
      let uri =
-       try Xml.parse_uri arg
+       try Xml.parse_uri_raw arg true
        with Invalid_argument _ ->
          error (f_"remote vmx ‘%s’ could not be parsed as a URI") arg in
      if uri.Xml.uri_scheme <> None && uri.Xml.uri_scheme <> Some "ssh" then


### PR DESCRIPTION
Use Xml.parse_uri_raw when parsing VMX SSH URIs so that percent-encoded characters like %2f are preserved in the path. On VMFS/ESXi, %2f is literal in filenames and must not be decoded.

Fixes: https://issues.redhat.com/browse/RHEL-136481

Uses:  https://github.com/libguestfs/libguestfs-common/pull/21