### PR TITLE
convert/convert_windows.ml: Attempt to remove VMware drivers

### DIFF
--- a/convert/convert_windows.ml
+++ b/convert/convert_windows.ml
@@ -338,7 +338,8 @@ let convert (g : G.guestfs) source inspect i_firmware
 
     unconfigure_xenpv ();
     unconfigure_prltools ();
-    unconfigure_vmwaretools ()
+    unconfigure_vmwaretools ();
+    remove_vmware_drivers ()
 
   (* [set_reg_val_dword_1 path name] creates a registry key
    * called [name = dword:1] in the registry [path].
@@ -544,6 +545,99 @@ if errorlevel 3010 exit /b 0
         Firstboot.add_firstboot_script g inspect.i_root
           "uninstall VMware Tools" fb_script
     ) vmwaretools_uninst
+
+  and remove_vmware_drivers () =
+    (* Essentially the previous step (unconfigure_vmwaretools) is
+     * expected to fail, so as a back-up do the next best thing and
+     * disable any VMware drivers.
+     *)
+    let fb_script = {|@echo off
+
+setlocal enabledelayedexpansion
+
+REM Check for admin privileges
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: This script must be run as Administrator!
+    exit /b 1
+)
+
+set "PNPUTIL=|} ^ pnputil ^ {|"
+
+echo.
+echo ====================================
+echo Remove VMware Driver Packages Script
+echo ====================================
+echo.
+
+echo Searching for VMware drivers and packages
+%pnputil% /enum-drivers > "%temp%\all_drivers.txt"
+
+echo Filtering lines with Published Name and VMware...
+findstr /i /c:"Published Name" /c:"Original Name" /c:"Provider Name" "%temp%\all_drivers.txt" > "%temp%\vmware_drivers.txt"
+
+set COUNT=0
+set LAST_PUBLISHED=
+set LAST_ORIGINAL=
+
+for /f "tokens=1,* delims=:" %%A in (%temp%\vmware_drivers.txt) do (
+    set LINE=%%A
+    set VALUE=%%B
+    set VALUE=!VALUE: =!
+
+    if /i "!LINE!"=="Published Name" (
+        set "LAST_PUBLISHED=!VALUE!"
+    )
+
+    if /i "!LINE!"=="Original Name" (
+        set "LAST_ORIGINAL=!VALUE!"
+    )
+
+    if /i "!LINE!"=="Provider Name" (
+        echo !VALUE! | findstr /i "VMware" >nul
+        if !errorlevel! == 0 (
+            REM This Published Name belongs to VMware
+            if not "!LAST_PUBLISHED!"=="" (
+                echo Found VMware driver: !LAST_ORIGINAL! ^(!LAST_PUBLISHED!^)
+                set INF_LIST[!COUNT!]=!LAST_PUBLISHED!
+                set /a COUNT+=1
+            )
+        )
+        set LAST_PUBLISHED=
+        set LAST_ORIGINAL=
+    )
+)
+
+:: --- Check if any drivers were found ---
+if %COUNT% EQU 0 (
+    echo.
+    echo ================================
+    echo No VMware driver packages found.
+    echo ================================
+    exit /b 0
+)
+
+echo Removing %COUNT% VMware driver package(s)
+for /l %%I in (0,1,%COUNT%-1) do (
+    set INF=!INF_LIST[%%I]!
+    if not "!INF!"=="" (
+        echo Removing !INF! ...
+        %pnputil% /delete-driver "!INF!" /uninstall /force
+        echo Done.
+    )
+)
+del "%temp%\pnputil_output.txt" >nul 2>&1
+
+echo Clean up temporary files
+del "%temp%\all_drivers.txt" >nul 2>&1
+del "%temp%\vmware_drivers.txt" >nul 2>&1
+
+echo.
+echo VMware driver removal process finished
+exit /b 0
+|} in
+       Firstboot.add_firstboot_script g inspect.i_root
+         "remove VMware drivers" fb_script
 
   and update_system_hive reg =
     (* Update the SYSTEM hive.  When this function is called the hive has

--- a/convert/convert_windows.ml
+++ b/convert/convert_windows.ml
@@ -27,6 +27,18 @@ open Types
 
 module G = Guestfs
 
+(* Standard location of [pnputil.exe].
+ *
+ * This is a virtual path created by Windows at runtime.  Because the
+ * firstboot service is 32 bit, when the service runs on a 64 bit
+ * Windows system, WOW64 filesystem redirection happens.  In this
+ * case it would mean that [%systemroot%\system32] would be redirected
+ * to [...\SysWOW64].  However we need to always run 64 bit pnputil
+ * which we have to do using the [sysnative] alias which bypasses
+ * redirection.
+ *)
+let pnputil = {|%systemroot%\sysnative\pnputil|}
+
 (* Convert Windows guests.
  *
  * This only does a "pre-conversion", the steps needed to get the
@@ -386,7 +398,7 @@ echo No pending reboot detected.
 
 for %%f in ("%inf_dir%*.inf") do (
 echo Installing: %%~nxf.
-%systemroot%\Sysnative\PnPutil -i -a "%%f"
+|} ^ pnputil ^ {| -i -a "%%f"
 if !errorlevel! neq 0 if !errorlevel! neq 259 (
 echo Failed to install %%~nxf.
 exit /b 249
@@ -632,7 +644,7 @@ if errorlevel 3010 exit /b 0
      * the way I build them).  In any case I had to add a firstboot
      * batch file which did this single command:
      *
-     * %systemroot%\Sysnative\PnPutil -i -a %systemroot%\Drivers\Virtio\*.inf
+     * pnputil -i -a %systemroot%\Drivers\Virtio\*.inf
      *)
     let node =
       Registry.get_node reg ["Microsoft"; "Windows"; "CurrentVersion"] in


### PR DESCRIPTION
We essentially expect that uninstalling VMware drivers will fail (because the VMware uninstaller is broken).  Therefore add a firstboot script which does the next best thing, removing VMware drivers by hand.

This requires Microsoft pnputil which is present in Windows >= Vista.

Most of the hard work was done by and all of the batch file was written by Vadim Rozenfeld.

Thanks: Vadim Rozenfeld
Fixes: https://issues.redhat.com/browse/RHEL-112249
Related: https://github.com/virtio-win/vmwremover/blob/main/drivers/remove_vmware_driver_packages.bat