### PR TITLE
smp: use cgroup CPU limits for appliance SMP

### DIFF
--- a/convert/convert.ml
+++ b/convert/convert.ml
@@ -67,13 +67,7 @@ let rec convert input_disks options source =
   let smp =
     match options.smp with
     | None ->
-       (* Default (if [--smp] option is not used) is to set the number
-        * according to the number of physical CPUs on the host, but
-        * limit it because each vCPU consumes guest RAM.  This is
-        * necessary to allow parallel mkinitrd which greatly improves
-        * performance.
-        *)
-       min 8 (Sysconf.nr_processors_online ())
+       min 8 (Cgroup.nr_cpus_available ())
     | Some smp -> smp in
   g#set_smp smp;
 


### PR DESCRIPTION
Use Cgroup.nr_cpus_available instead of nr_processors_online
to respect container cgroup CPU limits when setting SMP.

Resolves: https://redhat.atlassian.net/browse/RHEL-152766


related to https://github.com/libguestfs/libguestfs-common/pull/36