### PR TITLE
Can't boot UEFI VM after migration - grub configuration problem

### DIFF
--- a/convert/convert_linux.ml
+++ b/convert/convert_linux.ml
@@ -33,6 +33,22 @@ open Linux_kernels
 
 module G = Guestfs
 
+let fix_grub_uefi_commands g bootloader i_firmware =
+  match i_firmware with
+  | Firmware.I_UEFI _ ->
+      let grub_cfg = bootloader#get_config_file () in
+      if g#exists grub_cfg then (
+        try
+          ignore (g#sh (sprintf "sed -i 's/\\blinux16\\b/linuxefi/g;
+s/\\binitrd16\\b/initrdefi/g' %s"
+                          (Filename.quote grub_cfg)));
+          debug "Converted GRUB commands to UEFI format in %s" grub_cfg
+        with Guestfs.Error msg ->
+          warning "Failed to fix GRUB UEFI commands in %s: %s" grub_cfg msg
+      )
+  | I_BIOS ->
+      () (* No action needed for BIOS systems *)
+
 (* The conversion function. *)
 let convert (g : G.guestfs) source inspect i_firmware _ keep_serial_console _ =
   (*----------------------------------------------------------------------*)
@@ -1314,6 +1330,8 @@ fi
       (* Make sure the bootloader is up-to-date. *)
       bootloader#update ();
 
+      (* Fix GRUB commands for UEFI systems *)
+      fix_grub_uefi_commands g bootloader i_firmware;
       Linux.augeas_reload g
     );
 


### PR DESCRIPTION
UEFI boot mode based Linux VM, which reference /boot and /boot/efi partitions by device files (e.g. /dev/sdaX) in /etc/fstab, fail to boot post migration as virt-v2v re-writes the grub boot loader if it finds references to device files instead of disk UUIDs. The libguestfs appliance is configured to use BIOS boot mode. This causes the target VM's grub to be configured in BIOS boot mode. The target VM fails to boot in Qemu/KVM environment. The solution is to replace the BIOS boot mode specific grub commands which loads Linux kernel and init RAM disk, with UEFI  boot mode specific commands. This is done only if source VM is in UEFI mode.

Fixes: https://redhat.atlassian.net/browse/RHEL-173538