### PR TITLE
convert: Skip fsck after conversion for RHEL 7

### DIFF
--- a/convert/convert.ml
+++ b/convert/convert.ml
@@ -166,10 +166,19 @@ let rec convert input_disks options source =
     message (f_"Skipping fstrim (--no-fstrim specified)")
   );
 
-  (* Check (fsck) the filesystems after conversion. *)
-  g#umount_all ();
-  message (f_"Checking filesystem integrity after conversion");
-  do_fsck g;
+  (* Check (fsck) the filesystems after conversion.
+   *
+   * Skip this on RHEL 7 because of incompatibility issues with
+   * XFS in later kernels.
+   *)
+  (match inspect.i_distro, inspect.i_major_version with
+   | ("rhel" | "centos"), 7 ->
+      ()
+   | _ ->
+      g#umount_all ();
+      message (f_"Checking filesystem integrity after conversion");
+      do_fsck g;
+  );
 
   message (f_"Closing the overlay");
   g#umount_all ();


### PR DESCRIPTION
RHEL 7 XFS has subtle incompatibilties with later kernels.  There is a workaround for this in libguestfs, but it does not fix the problem entirely.  The fsck after conversion still fails because the block count is detected as being wrong.  The easiest thing to do here is to skip the fsck after conversion in this narrow case (RHEL 7 only) and it will all get fixed up properly when the guest boots next time.

Fixes: https://redhat.atlassian.net/browse/RHEL-178287
Thanks: Brian Foster, Eric Sandeen