### PR TITLE
inspector, in-place: Add <disk> <boot-order>#</boot-order> to XML output

### DIFF
--- a/inspector/create_inspector_xml.ml
+++ b/inspector/create_inspector_xml.ml
@@ -31,7 +31,8 @@ open DOM
  *   - The NBD input disks
  *   - The inspection data (Types.inspect)
  *)
-let rec create_inspector_xml input_disks inspect target_meta =
+let rec create_inspector_xml input_disks inspect
+          { target_firmware; target_boot_device } =
   let body = ref [] in
 
   (* Record the version of virt-v2v etc, mainly for debugging. *)
@@ -59,6 +60,13 @@ let rec create_inspector_xml input_disks inspect target_meta =
           List.push_back elems (e "allocated" [ "estimated", "true" ]
                                   [PCData (Int64.to_string real_size)])
       );
+      let boot_order =
+        match target_boot_device with
+        | None -> index + 1
+        | Some disk_index when disk_index = index -> 1
+        | Some _ -> index + 2 in
+      List.push_back elems (e "boot-order" []
+                              [PCData (Int.to_string boot_order)]);
 
       List.push_back disks (e "disk" [ "index", string_of_int index ] !elems)
   ) input_disks;
@@ -71,7 +79,7 @@ let rec create_inspector_xml input_disks inspect target_meta =
   List.push_back body
     (e "firmware"
        ["type",
-        string_of_target_firmware target_meta.target_firmware]
+        string_of_target_firmware target_firmware]
        []);
 
   (* The inspection data. *)

--- a/tests/test-in-place-xml.sh
+++ b/tests/test-in-place-xml.sh
@@ -76,5 +76,6 @@ grep '^<v2v-inspection' $out
 grep '<program>virt-v2v-inspector</program>' $out
 grep '<disks>' $out
 grep "<disk index='0'>" $out
+grep '<boot-order>1' $out
 grep '<distro>windows</distro>' $out
 grep '<osinfo>win2k22</osinfo>' $out

--- a/tests/test-inspector.sh
+++ b/tests/test-inspector.sh
@@ -71,5 +71,6 @@ grep '^<v2v-inspection' $out
 grep '<program>virt-v2v-inspector</program>' $out
 grep '<disks>' $out
 grep "<disk index='0'>" $out
+grep '<boot-order>1' $out
 grep '<distro>windows</distro>' $out
 grep '<osinfo>win2k22</osinfo>' $out


### PR DESCRIPTION
When using the virt-v2v-inspector or virt-v2v-in-place -O option to write informational XML, include the boot order for each disk. Example output after this change is:
```
<?xml version='1.0' encoding='utf-8'?>
<v2v-inspection>
  ...
  <disks>
    <disk index='0'>
      <virtual-size>21474836480</virtual-size>
      <allocated estimated='true'>12106633216</allocated>
      <boot-order>1</boot-order>
    </disk>
  </disks>
```
Reported-by: Elad Hazan
Fixes: https://redhat.atlassian.net/browse/RHEL-184508