### PR TITLE
convert: remove nutanix virtio drivers from windows vms

### DIFF
--- a/convert/convert_windows.ml
+++ b/convert/convert_windows.ml
@@ -215,6 +215,11 @@ let convert (g : G.guestfs) source inspect i_firmware
     let msifn s = if PCRE.matches re1 s then PCRE.replace re2 "/x" s else s in
     uninstallation_commands "VMware Tools" matchfn msifn "" in
 
+  (* Locate uninstallation commands for Nutanix VirtIO drivers. *)
+  let nutanix_uninsts =
+    let matchfn s = String.find s "Nutanix VirtIO" != -1 in
+    uninstallation_commands "Nutanix VirtIO" matchfn Fun.id "" in
+
   (*----------------------------------------------------------------------*)
   (* Perform the conversion of the Windows guest. *)
 
@@ -326,7 +331,8 @@ let convert (g : G.guestfs) source inspect i_firmware
 
     unconfigure_xenpv ();
     unconfigure_prltools ();
-    unconfigure_vmwaretools ()
+    unconfigure_vmwaretools ();
+    unconfigure_nutanix_virtio ()
 
   (* [set_reg_val_dword_1 path name] creates a registry key
    * called [name = dword:1] in the registry [path].
@@ -532,6 +538,22 @@ if errorlevel 3010 exit /b 0
         Firstboot.add_firstboot_script g inspect.i_root
           "uninstall VMware Tools" fb_script
     ) vmwaretools_uninst
+
+  and unconfigure_nutanix_virtio () =
+    List.iter (
+      fun uninst ->
+        let fb_script = sprintf
+                          {|@echo off
+
+echo uninstalling Nutanix VirtIO drivers
+rem ERROR_SUCCESS_REBOOT_REQUIRED (3010) is OK too
+%s
+if errorlevel 3010 exit /b 0
+|}
+                          uninst in
+        Firstboot.add_firstboot_script g inspect.i_root
+          "uninstall Nutanix VirtIO" fb_script
+    ) nutanix_uninsts
 
   and update_system_hive reg =
     (* Update the SYSTEM hive.  When this function is called the hive has


### PR DESCRIPTION
When converting a vm from nutanix, there may be existing virtio drivers installed on the vm. In order to have a fully supported vm after conversion, we want to ensure that the virtio drivers that are installed by virt-v2v are the ones that are in use. Because both the nutanix and upstream virtio drivers target the same device ids, if multiple virtio drivers are installed, windows will use the driver that has the highest version number. To avoid relying on version numbers, simply uninstall existing drivers if they're found in the guest.
