### PR TITLE
input/input_disk.ml: Only create a single instance of nbdkit-file-plugin

### DIFF
--- a/input/input_disk.ml
+++ b/input/input_disk.ml
@@ -47,6 +47,8 @@ module Disk = struct
     if not (Nbdkit.is_installed ()) then
       error (f_"nbdkit is not installed or not working.  It is required to \
                 use ‘-i disk’.");
+    if not (Nbdkit.version () >= (1, 44, 0)) then
+      error (f_"nbdkit must be >= 1.44.0 for input from local files");
     if not (Nbdkit.probe_plugin "file") then
       error (f_"nbdkit-file-plugin is not installed or not working");
     if options.read_only && not (Nbdkit.probe_filter "cow") then
@@ -92,14 +94,34 @@ module Disk = struct
       in
       loop args in
 
+    (* Only create a single instance of nbdkit-file-plugin below.  We will
+     * use the export name to select the disk.
+     *)
+    let nbdkit_file_instance = lazy (
+      let socket = sprintf "%s/infilesock" dir in
+      let cmd = Nbdkit.create ~name:"in" "file" in
+      if options.read_only then
+        Nbdkit.add_filter cmd "cow";
+
+      let exportdir = sprintf "%s/indisks" dir in
+      mkdir exportdir 0o700;
+
+      Nbdkit.add_arg cmd "dir" exportdir;
+      Nbdkit.reduce_memory_pressure cmd;
+      let _, pid = Nbdkit.run_unix socket cmd in
+
+      (* --exit-with-parent should ensure nbdkit is cleaned
+       * up when we exit, but it's not supported everywhere.
+       *)
+      On_exit.kill pid;
+
+      socket, exportdir
+    ) in
+
     (* Convert the command line disks to NBD URIs. *)
     let uris =
       List.mapi (
         fun i disk ->
-          let sockname = sprintf "in%d" i in
-          let socket = sprintf "%s/%s" dir sockname in
-          On_exit.unlink socket;
-
           if is_nbd_uri disk then (
             (* For nbd:// on the command line, proxy through
              * nbdkit-nbd-plugin.  This is not ideal.  We could
@@ -109,6 +131,10 @@ module Disk = struct
              * but would avoid needing an extra nbdkit proxy.
              * XXX
              *)
+            let sockname = sprintf "in%d" i in
+            let socket = sprintf "%s/%s" dir sockname in
+            On_exit.unlink socket;
+
             let cmd = Nbdkit.create ~name:sockname "nbd" in
             if options.read_only then
               Nbdkit.add_filter cmd "cow";
@@ -118,7 +144,9 @@ module Disk = struct
             (* --exit-with-parent should ensure nbdkit is cleaned
              * up when we exit, but it's not supported everywhere.
              *)
-            On_exit.kill pid
+            On_exit.kill pid;
+
+            NBD_URI.Unix (socket, None)
           )
           else (
             (* Local filename.  Use nbdkit-file-plugin for raw,
@@ -138,27 +166,25 @@ module Disk = struct
 
             match format with
             | "raw" ->
-               let cmd = Nbdkit.create ~name:sockname "file" in
-               if options.read_only then
-                 Nbdkit.add_filter cmd "cow";
-               Nbdkit.add_arg cmd "file" disk;
-               Nbdkit.reduce_memory_pressure cmd;
-               let _, pid = Nbdkit.run_unix socket cmd in
+               let socket, exportdir = Lazy.force nbdkit_file_instance in
+               let export = sprintf "disk%d" i in
+               symlink (absolute_path disk) (exportdir // export);
 
-               (* --exit-with-parent should ensure nbdkit is cleaned
-                * up when we exit, but it's not supported everywhere.
-                *)
-               On_exit.kill pid
+               NBD_URI.Unix (socket, Some export)
 
             | format ->
+               let sockname = sprintf "in%d" i in
+               let socket = sprintf "%s/%s" dir sockname in
+               On_exit.unlink socket;
+
                let cmd = QemuNBD.create disk in
                QemuNBD.set_snapshot cmd options.read_only;
                QemuNBD.set_format cmd (Some format);
                let _, pid = QemuNBD.run_unix socket cmd in
-               On_exit.kill pid
-          );
+               On_exit.kill pid;
 
-          NBD_URI.Unix (socket, None)
+               NBD_URI.Unix (socket, None)
+          );
         ) args in
 
     let s_disks =


### PR DESCRIPTION
For '-i disk' with raw files, we currently create one nbdkit instance per disk, each running nbdkit-file-plugin.  However it's possible to run only a single instance of nbdkit that serves all of the disks. The single instance of nbdkit should be slightly more memory efficient, but shouldn't have any impact on performance, and should otherwise be a completely neutral change.

Since we use nbdkit-cow-filter on top of the plugin, and since the cow filter only gained the ability to deal with multiple exports in nbdkit 1.44, we would need to use this version of nbdkit (but our current minimum is higher anyway).  I added a version check in any case.

In this change, only create a single instance of nbdkit-file-plugin. Use the 'dir=.../indisks' parameter to specify a directory where we will create one symlink to each raw format disk (with names like "indisks/disk0", "indisks/disk1" etc).  Then the client will select the correct disk by passing an NBD export name such as "disk0", "disk1" etc.

For example, running this virt-v2v command:
```
  $ ./run virt-v2v -i disk fedora-42-3disks.img fedora-42-3disks-1.img fedora-42-3disks-2.img -o null --memsize 8192
```
results in this shared instance of nbdkit plus shared directory:
```
  $ ps ax | grep nbdkit
  1712672 pts/6    Sl+    0:16 /usr/bin/nbdkit --name in --exit-with-parent --foreground --pidfile /tmp/v2vnbdkit.G5EwHy/nbdkit1.pid --unix /tmp/v2v.qyEwTo/infilesock --threads 16 --selinux-label system_u:object_r:svirt_socket_t:s0 -D nbdkit.backend.datapath=0 --filter cow file dir=/tmp/v2v.qyEwTo/indisks reduce-memory-pressure=on
  $ ls -al /tmp/v2v.qyEwTo/indisks
  total 0
  drwx------. 2 rjones rjones 45 Jul 21 16:05 .
  drwx------. 3 rjones rjones 52 Jul 21 16:05 ..
  lrwxrwxrwx. 1 rjones rjones 29 Jul 21 16:05 disk0 -> /var/tmp/fedora-42-3disks.img
  lrwxrwxrwx. 1 rjones rjones 31 Jul 21 16:05 disk1 -> /var/tmp/fedora-42-3disks-1.img
  lrwxrwxrwx. 1 rjones rjones 31 Jul 21 16:05 disk2 -> /var/tmp/fedora-42-3disks-2.img
```
See-also: https://libguestfs.org/nbdkit-file-plugin.1.html#DESCRIPTION