### PR TITLE
convert/convert_linux.ml: Use yum/dnf `clean_requirements_on_remove=False`

### DIFF
--- a/convert/convert_linux.ml
+++ b/convert/convert_linux.ml
@@ -1453,7 +1453,9 @@ fi
   and uninstall_packages_nonfatal pkgs =
     if pkgs <> [] then (
       let cmd =
-        try Guest_packages.uninstall_command pkgs inspect.i_package_management
+        try
+          Guest_packages.uninstall_command ~clean_requirements_on_remove:false
+            pkgs inspect.i_package_management
         with
         | Guest_packages.Unknown_package_manager msg
         | Guest_packages.Unimplemented_package_manager msg ->


### PR DESCRIPTION
When removing packages, use the yum or dnf option
`--setopt=clean_requirements_on_remove=False` (in dnf this is also known as `--no-autoremove`).  This removes only the named package, not dependencies.  This is in the interests of making the most minimal change possible to the guest during conversion.

Fixes: https://redhat.atlassian.net/browse/RHEL-233944

Note this requires the following change in the common submodule: https://github.com/libguestfs/libguestfs-common/pull/49