### PR TITLE
Add support for VMX input for virt-v2v-in-place

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
           # Install a bunch of bits to enable more tests
           dnf install -y \
             git kernel sqlite perl-hivex \
+            libnbd-devel nbdkit-devel \
             mingw-srvany-redistributable nbdkit-\* virt-v2v \
             guestfs-tools\*
 

--- a/in-place/virt-v2v-in-place.pod
+++ b/in-place/virt-v2v-in-place.pod
@@ -14,6 +14,11 @@ virt-v2v-in-place - Convert a guest to use KVM in-place
                    guest
                    [-O output.xml]
 
+ virt-v2v-in-place -i vmx [other -i* options]
+                   [virt-customize options]
+                   guest.vmx
+                   [-O output.xml]
+
 =head1 DESCRIPTION
 
 Virt-v2v-in-place converts a single guest from a foreign hypervisor to
@@ -36,6 +41,11 @@ This command will do an in-place conversion of F<filename.img>:
 If the guest has been copied to local libvirt then:
 
  virt-v2v-in-place -i libvirt guest
+
+If you have a VMware F<.vmx> file (and associated F<.vmdk> disk
+images) then:
+
+ virt-v2v-in-place -i vmx guest.vmx
 
 =head2 Output XML
 
@@ -141,6 +151,15 @@ disks.  See L</Minimal XML for -i libvirtxml option> below.
 =item B<-i> B<local>
 
 This is the same as I<-i disk>.
+
+=item B<-i> B<vmx>
+
+Set the input method to I<vmx>.
+
+In this mode you can read a VMware F<.vmx> file directly.  This is
+useful when VMware VMs are stored on an NFS server which you can mount
+directly, or where you have access by SSH to an ESXi hypervisor.  See
+L<virt-v2v-input-vmware(1)>.
 
 =item B<-ic> libvirtURI
 

--- a/input/input_vmx.ml
+++ b/input/input_vmx.ml
@@ -39,9 +39,6 @@ module VMX = struct
     if options.input_options <> [] then
       error (f_"no -io (input options) are allowed here");
 
-    if not options.read_only then
-      error (f_"in-place mode does not work with VMX source");
-
     let vmx_source =
       match args with
       | [arg] ->
@@ -74,7 +71,7 @@ module VMX = struct
              let cmd = QemuNBD.create
                          (absolute_path_from_other_file vmx_filename
                             filename) in
-             QemuNBD.set_snapshot cmd true; (* protective overlay *)
+             QemuNBD.set_snapshot cmd options.read_only; (* protective overlay *)
              QemuNBD.set_format cmd (Some "vmdk");
              let _, pid = QemuNBD.run_unix socket cmd in
              On_exit.kill pid;
@@ -117,7 +114,7 @@ module VMX = struct
                          virt-v2v-input-vmware(1) section \"NOTES\".");
 
              let cor = dir // "convert" in
-             let nbdkit = Nbdkit_ssh.create_ssh ~cor ?password
+             let nbdkit = Nbdkit_ssh.create_ssh ~read_only:options.read_only ~cor ?password
                             ~server ?port ?user flat_vmdk in
              let _, pid = Nbdkit.run_unix socket nbdkit in
              On_exit.kill pid;

--- a/input/nbdkit_ssh.ml
+++ b/input/nbdkit_ssh.ml
@@ -61,7 +61,7 @@ let create_ssh ?name ?cor ?(read_only=true) ?(retry=true)
    *)
   if verbose () then Nbdkit.add_filter_if_available cmd "count";
 
-  if read_only then (
+  if read_only then begin
     Nbdkit.add_filter cmd "cow";
 
     (* Add the cow-on-read flag if supported. *)
@@ -78,7 +78,7 @@ let create_ssh ?name ?cor ?(read_only=true) ?(retry=true)
      *)
     if Nbdkit.probe_filter_parameter "cow" "cow-block-size" then
       Nbdkit.add_arg cmd "cow-block-size" "4096";
-  )
+  end
   (* Handle the password parameter specially. *)
   (match password with
    | None -> ()

--- a/input/nbdkit_ssh.ml
+++ b/input/nbdkit_ssh.ml
@@ -30,7 +30,7 @@ type password =
   | PasswordFile of string
 
 (* Create an nbdkit module specialized for reading from SSH sources. *)
-let create_ssh ?name ?cor ?(retry=true)
+let create_ssh ?name ?cor ?(read_only=true) ?(retry=true)
       ~server ?port ?user ?password path =
   if not (Nbdkit.is_installed ()) then
     error (f_"nbdkit is not installed or not working");
@@ -38,7 +38,7 @@ let create_ssh ?name ?cor ?(retry=true)
   if not (Nbdkit.probe_plugin "ssh") then
     error (f_"nbdkit-ssh-plugin is not installed");
 
-  if not (Nbdkit.probe_filter "cow") then
+  if read_only && not (Nbdkit.probe_filter "cow") then
     error (f_"nbdkit-cow-filter is not installed or not working");
 
   (* Construct the nbdkit command. *)
@@ -61,19 +61,24 @@ let create_ssh ?name ?cor ?(retry=true)
    *)
   if verbose () then Nbdkit.add_filter_if_available cmd "count";
 
-  (* IMPORTANT! Add the COW filter.  It must be furthest away
-   * except for the rate filter.
-   *)
-  Nbdkit.add_filter cmd "cow";
+  if read_only then (
+    Nbdkit.add_filter cmd "cow";
 
-  (* Add the cow-on-read flag if supported. *)
-  (match cor with
-   | None -> ()
-   | Some cor ->
-      if Nbdkit.probe_filter_parameter "cow" "cow-on-read=.*/PATH" then
-        Nbdkit.add_arg cmd "cow-on-read" cor
-  );
+    (* Add the cow-on-read flag if supported. *)
+    (match cor with
+     | None -> ()
+     | Some cor ->
+        if Nbdkit.probe_filter_parameter "cow" "cow-on-read=.*/PATH" then
+          Nbdkit.add_arg cmd "cow-on-read" cor
+    );
 
+    (* If the filter supports it, enable cow-block-size (added in
+     * nbdkit 1.27.6).  This helps to reduce fragmentated small
+     * extent and read requests.
+     *)
+    if Nbdkit.probe_filter_parameter "cow" "cow-block-size" then
+      Nbdkit.add_arg cmd "cow-block-size" "4096";
+  )
   (* Handle the password parameter specially. *)
   (match password with
    | None -> ()

--- a/input/nbdkit_ssh.mli
+++ b/input/nbdkit_ssh.mli
@@ -24,6 +24,7 @@ type password =                 (** Use [None] for no password *)
 
 val create_ssh : ?name:string ->
                  ?cor:string ->
+                 ?read_only:bool ->
                  ?retry:bool ->
                  server:string ->
                  ?port:string ->


### PR DESCRIPTION
# Summary

This PR enables **VMware `.vmx` file support** for **`virt-v2v-in-place`** conversions, allowing users to convert VMware VMs to KVM **directly in-place** without requiring the full `virt-v2v` conversion workflow.

## Highlights

- **VMX input support for in-place conversions**
  - Users can now use VMware `.vmx` files as input with `virt-v2v-in-place`.

- **Removed conversion restriction**
  - Eliminated the error that previously prevented **VMX input** from being used with **in-place mode**.

- **Enhanced snapshot handling**
  - Updated **QemuNBD** to conditionally enable snapshot mode based on the **`read_only`** flag.

- **Improved SSH connectivity**
  - Extended the **`Nbdkit_ssh`** module with a **`read_only`** parameter to support both read-only and read-write conversion workflows.

- **Optimized COW filter behavior**
  - Made the **copy-on-write (COW) filter** conditional for non-read-only mode.
  - Improves performance when direct write access is available.

- **Performance enhancements**
  - Added support for the **`cow-block-size`** parameter (**nbdkit 1.27.6+**).
  - Reduces fragmented extents and improves overall read performance.

- **Documentation updates**
  - Updated the **`virt-v2v-in-place`** man page with:
    - VMX input usage examples.
    - Reference to **`virt-v2v-input-vmware(1)`**.

## Use Cases

Users can now directly convert VMware VMs stored on:

- **VMFS datastores** mounted with **read-write access**.
- **NFS mounts** accessible from the conversion host.
- **ESXi hypervisors** accessible via **SSH**.

## Example Usage

```bash
virt-v2v-in-place -i vmx guest.vmx
```

## 📂 Files Modified

### Documentation
- **`virt-v2v-in-place.pod`**
  - Added VMX usage examples.
  - Added reference to `virt-v2v-input-vmware(1)`.

### Source Code
- **`input_vmx.ml`**
  - Removed the in-place conversion restriction for VMX inputs.

- **`nbdkit_ssh.ml`**
  - Added `read_only` parameter support.
  - Optimized COW filter behavior.
  - Added `cow-block-size` support.

- **`nbdkit_ssh.mli`**
  - Updated interface signature to include the new parameter.

### Translations
- **`virt-v2v.pot`**
  - Removed the obsolete VMX in-place mode error message.