### PR TITLE
input: ova: Reconstruct DSP0243 chunked disks

### DIFF
--- a/input/OVF.ml
+++ b/input/OVF.ml
@@ -33,6 +33,8 @@ type disk = {
   source_disk : Types.source_disk;
   href : string;                (* The <File href> from the OVF file. *)
   compressed : bool;            (* If the file is gzip compressed. *)
+  chunked : bool;                (* If the file is split into DSP0243
+                                   * chunks (ovf:chunkSize present). *)
 }
 
 let xpathctx_of_ovf ovf_filename =
@@ -155,6 +157,16 @@ and parse_disks xpathctx =
         | Some "gzip" -> true
         | Some s -> error (f_"unsupported compression in OVF: %s") s in
 
+      (* DSP0243 clauses 542-556: a disk larger than a chunk boundary
+       * is split into sequential files named <href>.NNNNNNNNN which
+       * must be concatenated to reconstruct it.  The presence of the
+       * ovf:chunkSize attribute is what distinguishes this from a
+       * VMware CBT/snapshot delta chain, which has the same filename
+       * shape but a different meaning (RHBZ#1570407).
+       *)
+      let expr = sprintf "/ovf:Envelope/ovf:References/ovf:File[@ovf:id='%s']/@ovf:chunkSize" file_ref in
+      let chunked = xpath_string expr <> None in
+
       let disk = {
         source_disk = {
           s_disk_id = i;
@@ -162,6 +174,7 @@ and parse_disks xpathctx =
         };
         href = href;
         compressed = compressed;
+        chunked = chunked;
       } in
       List.push_front disk disks;
     ) else

--- a/input/OVF.mli
+++ b/input/OVF.mli
@@ -25,6 +25,9 @@ type disk = {
   source_disk : Types.source_disk;
   href : string;                (** The <File href> from the OVF file. *)
   compressed : bool;            (** If the href is gzip compressed. *)
+  chunked : bool;                (** If the href is split into DSP0243
+                                    chunks (ovf:chunkSize present on the
+                                    ovf:File element). *)
 }
 (** A VMDK disk from a parsed OVF. *)
 

--- a/input/input_ova.ml
+++ b/input/input_ova.ml
@@ -102,8 +102,8 @@ module OVA = struct
     (* Convert the disk hrefs into qemu URIs. *)
     let qemu_uris =
       List.map (
-        fun { OVF.href; compressed } ->
-          let file_ref = find_file_or_snapshot ova_t href manifest in
+        fun { OVF.href; compressed; chunked } ->
+          let file_ref = find_file_or_snapshot ova_t href manifest chunked in
 
           match compressed, file_ref with
           | false, OVA.LocalFile filename ->
@@ -203,7 +203,7 @@ module OVA = struct
 
     source, uris
 
-  and find_file_or_snapshot ova_t href manifest =
+  and find_file_or_snapshot ova_t href manifest chunked =
     match OVA.resolve_href ova_t href with
     | Some f -> f
     | None ->
@@ -217,15 +217,69 @@ module OVA = struct
              | OVA.TarFile (_, filename) ->
                 get_snapshot_if_matches href filename
          ) files in
-       (* Pick highest. *)
-       let snapshots = List.sort (fun a b -> compare b a) snapshots in
-       match snapshots with
-       | [] -> error_missing_href href
-       | snapshot::_ ->
-          let href = sprintf "%s.%s" href snapshot in
-          match OVA.resolve_href ova_t href with
-          | None -> error_missing_href href
+       if chunked then (
+         (* DSP0243 chunked disk (ovf:chunkSize was present): these
+          * must all be concatenated, in ascending order, to
+          * reconstruct the disk -- unlike a VMware snapshot chain
+          * (below) where only the highest-numbered file is wanted.
+          * The suffixes are fixed-width zero-padded decimal numbers,
+          * so plain string comparison already sorts them numerically.
+          *)
+         let snapshots = List.sort compare snapshots in
+         match snapshots with
+         | [] -> error_missing_href href
+         | _ -> concat_chunks ova_t href snapshots
+       )
+       else (
+         (* RHBZ#1570407: VMware-generated OVA files can reference a
+          * snapshot chain; the highest-numbered file is the current
+          * differencing disk and is the only one we want.
+          *)
+         let snapshots = List.sort (fun a b -> compare b a) snapshots in
+         match snapshots with
+         | [] -> error_missing_href href
+         | snapshot::_ ->
+            let href = sprintf "%s.%s" href snapshot in
+            match OVA.resolve_href ova_t href with
+            | None -> error_missing_href href
+            | Some f -> f
+       )
+
+  (* Concatenate the (already sorted, ascending) chunk files for
+   * [href] into a single temporary file and return it as a
+   * LocalFile.  This gives up the tar zero-copy optimization for
+   * chunked disks, the same tradeoff already made for compressed
+   * disks below.
+   *)
+  and concat_chunks ova_t href snapshots =
+    let chunk_files =
+      List.map (
+        fun snapshot ->
+          let chunk_href = sprintf "%s.%s" href snapshot in
+          match OVA.resolve_href ova_t chunk_href with
+          | None -> error_missing_href chunk_href
           | Some f -> f
+      ) snapshots in
+
+    let tmpfile =
+      Filename.temp_file ~temp_dir:Utils.large_tmpdir "ova-chunks" ".vmdk" in
+    On_exit.unlink tmpfile;
+
+    List.iter (
+      fun chunk ->
+        let cmd =
+          match chunk with
+          | OVA.LocalFile filename ->
+             sprintf "cat %s >> %s" (quote filename) (quote tmpfile)
+          | OVA.TarFile (tar, filename) ->
+             sprintf "tar -xf %s -O %s >> %s"
+               (quote tar) (quote filename) (quote tmpfile) in
+        if shell_command cmd <> 0 then
+          error (f_"-i ova: error reconstructing chunked disk ‘%s’, see \
+                    earlier error messages") href
+    ) chunk_files;
+
+    OVA.LocalFile tmpfile
 
   (* If [filename] matches [<href>.\d+] then return [Some snapshot]. *)
   and get_snapshot_if_matches href filename =


### PR DESCRIPTION
## Summary

`-i ova` silently discards all but the highest-numbered chunk of a
DSP0243 chunked disk instead of concatenating them, which throws away
the chunk containing the partition table/boot sector and breaks guest
inspection ("no root device found") on an otherwise valid, spec-
conformant OVA.

## Root cause

`find_file_or_snapshot` / `get_snapshot_if_matches` in
`input/input_ova.ml` were written for RHBZ#1570407: VMware-generated
OVAs whose href points to a stale name, with the real disk shipped as
a numbered snapshot (`disk1.vmdk.000000000`, ...), where picking the
highest-numbered file is correct. DSP0243 defines an unrelated,
spec-mandated convention with the *same* filename shape: a disk over
the chunk-size boundary is split into sequential pieces that must all
be concatenated to reconstruct it. There was no code path that
concatenated multiple matches -- it always resolved to exactly one
file, so chunked disks were silently truncated to their last chunk.

## Fix

- `OVF.ml`/`OVF.mli`: record whether `ovf:chunkSize` is present on the
  `ovf:File` element for each disk (`disk.chunked`).
- `input_ova.ml`: `find_file_or_snapshot` now branches on `chunked`.
  When set, all matching `<href>.NNNNNNNNN` files are sorted in
  ascending order and concatenated into a temporary file via
  `concat_chunks` (handles both the plain-directory and
  tar-optimized cases). When unset, the existing "pick the highest"
  snapshot-chain behaviour for RHBZ#1570407 is unchanged.

## Testing

Verified with the reproducer OVA attached to the issue (CirrOS disk
converted to streamOptimized VMDK, split into two DSP0243 chunks via
`ovf:chunkSize`). Before the fix: inspection fails with "No root
device found in this operating system image." After the fix:
inspection and boot-device detection succeed.

Fixes #189